### PR TITLE
Fix undefined display

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
@@ -352,10 +352,14 @@ export class DataCartDetails extends React.Component {
                             <td style={styles.tdHeader}>Started</td>
                             <td style={styles.tdData}>{moment(this.props.cartDetails.started_at).format('h:mm:ss a, MMMM Do YYYY')}</td>
                         </tr>
-                        <tr>
-                            <td style={styles.tdHeader}>Finished</td>
-                            <td style={styles.tdData}>{moment(this.props.cartDetails.finished_at).format('h:mm:ss a, MMMM Do YYYY')}</td>
-                        </tr>
+                        {this.props.cartDetails.finished_at ? 
+                            <tr>
+                                <td style={styles.tdHeader}>Finished</td>
+                                <td style={styles.tdData}>{moment(this.props.cartDetails.finished_at).format('h:mm:ss a, MMMM Do YYYY')}</td>
+                            </tr>
+                        :
+                            null
+                        }
                     </tbody>
                 </table>
             </div>

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartDetails.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartDetails.spec.js
@@ -77,6 +77,20 @@ describe('DataCartDetails component', () => {
         expect(table.find('tr').at(3).find('td').last().text()).toEqual('6:35:22 pm, May 22nd 2017');
     });
 
+    it('should only render "Finished" table data if run has finished', () => {
+        let props = getProps();
+        props.cartDetails.finished_at = "";
+        const wrapper = getWrapper(props);
+        let table = wrapper.find('table').at(6);
+        expect(table.find('tr')).toHaveLength(3);
+        const nextProps = getProps();
+        wrapper.setProps(nextProps);
+        table = wrapper.find('table').at(6);
+        expect(table.find('tr')).toHaveLength(4);
+        expect(table.find('tr').at(3).find('td').first().text()).toEqual('Finished');
+        expect(table.find('tr').at(3).find('td').last().text()).toEqual('6:35:22 pm, May 22nd 2017');
+    });
+
     it('should handle setting state of datacartDetails when component updates', () => {
         let props = getProps();
         props.cartDetails.status = 'SUBMITTED';


### PR DESCRIPTION
This pr stops the download page from displaying the finished_at time until the run actually has a finished time. 