### PR TITLE
Fix wfs projection

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -533,7 +533,7 @@ def geopackage_export_task(self, result={}, run_uid=None, task_uid=None, stage_d
     return result
 
 
-@app.task(name='WFSExport', bind=True, base=FormatTask)
+@app.task(name='WFSExport', bind=True, base=ExportTask)
 def wfs_export_task(self, result={}, layer=None, config=None, run_uid=None, task_uid=None, stage_dir=None,
                     job_name=None, bbox=None, service_url=None, name=None, service_type=None, user_details=None):
     """

--- a/eventkit_cloud/utils/tests/test_wfs.py
+++ b/eventkit_cloud/utils/tests/test_wfs.py
@@ -28,7 +28,7 @@ class TestWFSToGPKG(TransactionTestCase):
         name = 'Great export'
         service_url = 'http://my-service.org/some-server/wms?'
         expected_url = '{}{}'.format(service_url.rstrip('?'), '?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME={}&SRSNAME=EPSG:4326'.format(layer))
-        cmd = Template("ogr2ogr -skipfailures -t_srs EPSG:3857 -spat $minX $minY $maxX $maxY -f GPKG $gpkg WFS:'$url'")
+        cmd = Template("ogr2ogr -skipfailures -spat $minX $minY $maxX $maxY -f GPKG $gpkg WFS:'$url'")
         cmd = cmd.safe_substitute({'gpkg': gpkg, 'url': expected_url, 'minX': bbox[0], 'minY': bbox[1], 'maxX': bbox[2], 'maxY': bbox[3]})
         exists.return_value = True
         self.task_process.return_value = Mock(exitcode=0)

--- a/eventkit_cloud/utils/wfs.py
+++ b/eventkit_cloud/utils/wfs.py
@@ -52,7 +52,7 @@ class WFSToGPKG(object):
             self.service_url = self.service_url.rstrip('/\\')
         finally:
             self.service_url = '{}{}'.format(self.service_url,
-                                             '?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME={}'.format(
+                                             '?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME={}&SRSNAME=EPSG:4326'.format(
                                                  self.layer))
 
         if self.bbox:

--- a/eventkit_cloud/utils/wfs.py
+++ b/eventkit_cloud/utils/wfs.py
@@ -33,9 +33,9 @@ class WFSToGPKG(object):
         self.task_uid = task_uid
         if self.bbox:
             self.cmd = Template(
-                "ogr2ogr -skipfailures -t_srs EPSG:3857 -spat $minX $minY $maxX $maxY -f GPKG $gpkg WFS:'$url'")
+                "ogr2ogr -skipfailures -spat $minX $minY $maxX $maxY -f GPKG $gpkg WFS:'$url'")
         else:
-            self.cmd = Template("ogr2ogr -skipfailures -t_srs EPSG:3857 -f GPKG $gpkg WFS:'$url'")
+            self.cmd = Template("ogr2ogr -skipfailures -f GPKG $gpkg WFS:'$url'")
 
     def convert(self, ):
         """
@@ -52,7 +52,7 @@ class WFSToGPKG(object):
             self.service_url = self.service_url.rstrip('/\\')
         finally:
             self.service_url = '{}{}'.format(self.service_url,
-                                             '?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME={}&SRSNAME=EPSG:4326'.format(
+                                             '?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME={}'.format(
                                                  self.layer))
 
         if self.bbox:


### PR DESCRIPTION
This just removes converting the WFS data to 3857 as a part of the WFS export task, which subsequently fixes an issue with clipping the data.

To test export a WFS provider and ensure that the data exists and is properly clipped. 