### PR TITLE
display polygons as points if scale is too small

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -15,22 +15,25 @@ import InvalidDrawWarning from '../MapTools/InvalidDrawWarning.js';
 import DropZone from '../MapTools/DropZone.js';
 import {generateDrawLayer, generateDrawBoxInteraction, generateDrawFreeInteraction, 
     serialize, isGeoJSONValid, createGeoJSON, createGeoJSONGeometry, zoomToExtent, clearDraw,
-    MODE_DRAW_BBOX, MODE_DRAW_FREE, MODE_NORMAL, zoomToGeometry} from '../../utils/mapUtils'
+    MODE_DRAW_BBOX, MODE_DRAW_FREE, MODE_NORMAL, zoomToGeometry, featureToPoint} from '../../utils/mapUtils'
 
 export const RED_STYLE = new ol.style.Style({
     stroke: new ol.style.Stroke({
         color: '#ce4427',
         width: 6,
-        zIndex: 100,
-    })
+        
+    }),
+    image: null,
+    zIndex: Infinity,
 });
 
 export const BLUE_STYLE = new ol.style.Style({
     stroke: new ol.style.Stroke({
         color: '#4498c0',
-        width: 6,
-        zIndex: 1,
-    })
+        width: 4,
+    }),
+    image: null,
+    zIndex: 1
 });
 
 export class MapView extends Component {
@@ -55,6 +58,8 @@ export class MapView extends Component {
         this.onDrawStart = this.onDrawStart.bind(this);
         this.updateMode = this.updateMode.bind(this);
         this.setMapView = this.setMapView.bind(this);
+        this.defaultStyleFunction = this.defaultStyleFunction.bind(this);
+        this.selectedStyleFunction = this.selectedStyleFunction.bind(this);
         this.state = {
             selectedFeature: null,
             groupedFeatures: [],
@@ -78,7 +83,7 @@ export class MapView extends Component {
         this.source = new ol.source.Vector({wrapX: false});
         this.layer = new ol.layer.Vector({
             source: this.source,
-            style: BLUE_STYLE
+            style: this.defaultStyleFunction
         });
         this.drawLayer = generateDrawLayer();
 
@@ -222,9 +227,8 @@ export class MapView extends Component {
                     const oldFeature = this.source.getFeatureById(this.state.selectedFeature);
                     this.setFeatureNotSelected(oldFeature);
                 }
-                const style = feature.getStyle();
                 // if clicked on feature is already selected it should be deselected
-                if(style && style == RED_STYLE) {
+                if(this.state.selectedFeature && this.state.selectedFeature == feature.getId()) {
                     this.setFeatureNotSelected(feature);
                     this.setState({selectedFeature: null});
                 }
@@ -238,8 +242,12 @@ export class MapView extends Component {
                     if(!ol.extent.containsExtent(mapExtent, feature.getGeometry().getExtent())) {
                         this.map.getView().setCenter(ol.extent.getCenter(feature.getGeometry().getExtent()));
                     }
-                    // if it is in view trigger an animation
+                    // if it is in view and not a polygon, trigger an animation
                     else {
+                        if (!this.displayAsPoint(feature)) {
+                            return;
+                        }
+                        
                         const start = new Date().getTime();
                         const geom = feature.getGeometry();
                         if (this.listener) {
@@ -328,14 +336,67 @@ export class MapView extends Component {
 
     // helper function that changes feature style to unselected
     setFeatureNotSelected(feature) {
-        feature.setStyle(BLUE_STYLE);
-        feature.getStyle().setZIndex(1);
+        feature.setStyle(this.defaultStyleFunction);
     }
 
     // helper function that changes feature style to selected
     setFeatureSelected(feature) {
-        feature.setStyle(RED_STYLE);
-        feature.getStyle().setZIndex(100);
+        feature.setStyle(this.selectedStyleFunction);
+    }
+
+    displayAsPoint(feature) {
+        if(!feature) {return null}
+        const extent = feature.getGeometry().getExtent();
+        const topLeft = this.map.getPixelFromCoordinate(ol.extent.getTopLeft(extent));
+        const bottomRight = this.map.getPixelFromCoordinate(ol.extent.getBottomRight(extent));
+        if(topLeft && bottomRight) {
+            const height =  bottomRight[1] - topLeft[1];
+            const width = bottomRight[0] - topLeft[0];
+            return !((height > 10 || width > 10) && height * width >= 50);    
+        }
+        return true
+    }
+
+    defaultStyleFunction(feature, resolution) {
+        const pointStyle = new ol.style.Style({
+            geometry: featureToPoint,
+            image: new ol.style.Circle({
+                radius: 6,
+                fill: new ol.style.Fill({
+                    color: '#4598bf',
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#fff',
+                    width: 2
+                }),
+            }),
+            zIndex: 1
+        });
+        if(this.displayAsPoint(feature)) {
+            return pointStyle;
+        }
+        return BLUE_STYLE;
+    }
+
+    selectedStyleFunction(feature, resolution) {
+        const pointStyle = new ol.style.Style({
+            geometry: featureToPoint,
+            image: new ol.style.Circle({
+                radius: 6,
+                fill: new ol.style.Fill({
+                    color: '#ce4427'
+                }),
+                stroke: new ol.style.Stroke({
+                    color: '#fff',
+                    width: 2
+                }),
+            }),
+            zIndex: Infinity
+        });
+        if(this.displayAsPoint(feature)) {
+            return pointStyle;
+        }
+        return RED_STYLE;
     }
 
     handleSearch(result) {

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.js
@@ -119,7 +119,7 @@ describe('MapView component', () => {
         expect(sourceSpy.calledWith({wrapX: false})).toBe(true);
         expect(layerSpy.calledTwice).toBe(true);
         expect(layerSpy.calledWith(
-            {source: wrapper.instance().source, style: BLUE_STYLE}
+            {source: wrapper.instance().source, style: wrapper.instance().defaultStyleFunction}
         )).toBe(true);
         expect(addLayerSpy.calledTwice).toBe(true);
         expect(addLayerSpy.calledWith(wrapper.instance().layer)).toBe(true);
@@ -577,28 +577,19 @@ describe('MapView component', () => {
         expect(handleClickSpy.calledWith('1234')).toBe(true);
     });
 
-    it('setFeatureNotSelected should set style to BLUE_STYLE and z-index 1', () => {
+    it('setFeatureNotSelected should set style to defaultStyle and z-index 1', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         const setStyleSpy = new sinon.spy(ol.Feature.prototype, 'setStyle');
-        const getStyleSpy = new sinon.spy(ol.Feature.prototype, 'getStyle');
-        const setIndexSpy = new sinon.spy(ol.style.Style.prototype, 'setZIndex');
         const feature = new ol.Feature();
         expect(setStyleSpy.notCalled).toBe(true);
-        expect(getStyleSpy.notCalled).toBe(true);
-        expect(setIndexSpy.notCalled).toBe(true);
         wrapper.instance().setFeatureNotSelected(feature);
         expect(setStyleSpy.called).toBe(true);
-        expect(setStyleSpy.calledWith(BLUE_STYLE)).toBe(true);
-        expect(getStyleSpy.called).toBe(true);
-        expect(setIndexSpy.called).toBe(true);
-        expect(setIndexSpy.calledWith(1)).toBe(true);
+        expect(setStyleSpy.calledWith(wrapper.instance().defaultStyleFunction)).toBe(true);
         setStyleSpy.restore();
-        getStyleSpy.restore();
-        setIndexSpy.restore();
     });
 
-    it('setFeatureSelected should set style to RED_STYLE and z-index 100', () => {
+    it('setFeatureSelected should set style to selectedStyle and z-index 100', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         const setStyleSpy = new sinon.spy(ol.Feature.prototype, 'setStyle');
@@ -606,17 +597,102 @@ describe('MapView component', () => {
         const setIndexSpy = new sinon.spy(ol.style.Style.prototype, 'setZIndex');
         const feature = new ol.Feature();
         expect(setStyleSpy.notCalled).toBe(true);
-        expect(getStyleSpy.notCalled).toBe(true);
-        expect(setIndexSpy.notCalled).toBe(true);
         wrapper.instance().setFeatureSelected(feature);
         expect(setStyleSpy.called).toBe(true);
-        expect(setStyleSpy.calledWith(RED_STYLE)).toBe(true);
-        expect(getStyleSpy.called).toBe(true);
-        expect(setIndexSpy.called).toBe(true);
-        expect(setIndexSpy.calledWith(100)).toBe(true);
+        expect(setStyleSpy.calledWith(wrapper.instance().selectedStyleFunction)).toBe(true);
         setStyleSpy.restore();
-        getStyleSpy.restore();
-        setIndexSpy.restore();
+    });
+
+    it('displayAsPoint should return true or false if a feature is displayed small enough to be a point', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        expect(wrapper.instance().displayAsPoint()).toBe(null);
+        const coords = [[[-15,-14],[14,-14],[14,12],[-15,12],[-15,-14]]];
+        const bbox = [-15,-14,14,12];
+        const feature = new ol.Feature({
+            geometry: new ol.geom.Polygon(coords)
+        });
+        const extentSpy = new sinon.spy(ol.geom.Polygon.prototype, 'getExtent');
+        const geomSpy = new sinon.spy(ol.Feature.prototype, 'getGeometry');
+        const pixelSpy = new sinon.spy(ol.Map.prototype, 'getPixelFromCoordinate');
+        const tlSpy = new sinon.spy(ol.extent, 'getTopLeft');
+        const brSpy = new sinon.spy(ol.extent, 'getBottomRight');
+        const result = wrapper.instance().displayAsPoint(feature);
+        expect(result).toBe(true);
+        expect(extentSpy.calledOnce).toBe(true);
+        expect(geomSpy.calledOnce).toBe(true);
+        expect(pixelSpy.calledTwice).toBe(true);
+        expect(tlSpy.calledOnce).toBe(true);
+        expect(brSpy.calledOnce).toBe(true);
+        extentSpy.restore();
+        geomSpy.restore();
+        pixelSpy.restore();
+        tlSpy.restore();
+        brSpy.restore();
+    });
+
+    it('default style function should return either a point style or BLUE_STYLE', () => {
+        const coords = [[[-15,-14],[14,-14],[14,12],[-15,12],[-15,-14]]];
+        const bbox = [-15,-14,14,12];
+        const feature = new ol.Feature({
+            geometry: new ol.geom.Polygon(coords)
+        });
+        const center = ol.extent.getCenter(feature.getGeometry().getExtent());
+        const point = new ol.geom.Point(center);
+        const featureStub = new sinon.stub(utils, 'featureToPoint');
+        featureStub.withArgs(feature).returns(point)
+        const displayStub = new sinon.stub(MapView.prototype, 'displayAsPoint');
+        displayStub.withArgs(feature).returns(true)
+        const circle = ol.style.Circle;
+        ol.style.Circle = new sinon.spy();
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        const style = wrapper.instance().defaultStyleFunction(feature, null);
+        expect(style).not.toEqual(BLUE_STYLE);
+        expect(style.getGeometry()).toEqual(utils.featureToPoint);
+        expect(style.getImage()).not.toBe(null);
+
+        displayStub.withArgs(feature).returns(false);
+        const style2 = wrapper.instance().defaultStyleFunction(feature, null);
+        expect(style2).toEqual(BLUE_STYLE);
+        expect(style2.getGeometry()).not.toEqual(utils.featureToPoint);
+        expect(style2.getImage()).toBe(null);
+
+        featureStub.restore();
+        displayStub.restore();
+        ol.style.Circle = circle;
+    });
+
+    it('selected style function should return either a point style or RED_STYLE', () => {
+        const coords = [[[-15,-14],[14,-14],[14,12],[-15,12],[-15,-14]]];
+        const bbox = [-15,-14,14,12];
+        const feature = new ol.Feature({
+            geometry: new ol.geom.Polygon(coords)
+        });
+        const center = ol.extent.getCenter(feature.getGeometry().getExtent());
+        const point = new ol.geom.Point(center);
+        const featureStub = new sinon.stub(utils, 'featureToPoint');
+        featureStub.withArgs(feature).returns(point)
+        const displayStub = new sinon.stub(MapView.prototype, 'displayAsPoint');
+        displayStub.withArgs(feature).returns(true)
+        const circle = ol.style.Circle;
+        ol.style.Circle = new sinon.spy();
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        const style = wrapper.instance().selectedStyleFunction(feature, null);
+        expect(style).not.toEqual(RED_STYLE);
+        expect(style.getGeometry()).toEqual(utils.featureToPoint);
+        expect(style.getImage()).not.toBe(null);
+
+        displayStub.withArgs(feature).returns(false);
+        const style2 = wrapper.instance().selectedStyleFunction(feature, null);
+        expect(style2).toEqual(RED_STYLE);
+        expect(style2.getGeometry()).not.toEqual(utils.featureToPoint);
+        expect(style2.getImage()).toBe(null);
+
+        featureStub.restore();
+        displayStub.restore();
+        ol.style.Circle = circle;
     });
 
     it('handleSearch should clearDraw, hide warning, create and add a feature, zoom to feature, and call onMapFitler if its a polygon', () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/mapUtils.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/mapUtils.spec.js
@@ -480,4 +480,26 @@ describe('mapUtils', () => {
         expect(center.calledOnce).toBe(true);
         expect(geom.getCoordinates.calledOnce).toBe(true);
     });
+
+    it('featureToPoint should return a point representing the center of a feature\'s extent', () => {
+        expect(utils.featureToPoint()).toBe(null);
+        const coords = [[[-15,-14],[14,-14],[14,12],[-15,12],[-15,-14]]];
+        const bbox = [-15,-14,14,12];
+        const feature = new ol.Feature({
+            geometry: new ol.geom.Polygon(coords)
+        });
+        const expectedCoords = ol.extent.getCenter(bbox);
+        const centerSpy = new sinon.spy(ol.extent, 'getCenter');
+        const geomSpy = new sinon.spy(ol.Feature.prototype, 'getGeometry');
+        const extentSpy = new sinon.spy(ol.geom.Polygon.prototype, 'getExtent');
+        const point = utils.featureToPoint(feature);
+        expect(centerSpy.calledOnce).toBe(true);
+        expect(centerSpy.calledWith(bbox)).toBe(true);
+        expect(geomSpy.calledOnce).toBe(true);
+        expect(extentSpy.calledOnce).toBe(true);
+        expect(point.getCoordinates()).toEqual(expectedCoords);
+        centerSpy.restore();
+        geomSpy.restore();
+        extentSpy.restore();
+    });
 });

--- a/eventkit_cloud/ui/static/ui/app/utils/mapUtils.js
+++ b/eventkit_cloud/ui/static/ui/app/utils/mapUtils.js
@@ -257,3 +257,9 @@ export function zoomToGeometry(geom, map) {
         map.getView().setCenter(geom.getCoordinates())
     }
 }
+
+export function featureToPoint(feature) {
+    if (!feature) {return null}
+    const center = ol.extent.getCenter(feature.getGeometry().getExtent());
+    return new ol.geom.Point(center);
+}


### PR DESCRIPTION
This pr should show polygons as points if they do not have at least one edge of extent 10 pixels long and a min extent area of 50 pixels. These numbers are chosen somewhat arbitrarily and can be adjusted if necessary. 
![points_and_polygons_1](https://user-images.githubusercontent.com/16799449/29519452-883891d4-864b-11e7-89bf-ae954abc981a.PNG)
![points_and_polygons_2](https://user-images.githubusercontent.com/16799449/29519455-89a45724-864b-11e7-8ff3-24b21f2d3004.PNG)
