### PR TITLE
Add node_modules to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ db_dir
 *.komodoproject
 .komodotools
 staticfiles/
+node_modules/
 
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
I realize that a local copy of node_modules isn't necessary, but it helps with development workflow for things like auto-complete and auto-imports.