### PR TITLE
Make basemap configurable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,7 @@ services:
         - GEOCODING_API_URL
         - GEOCODING_API_TYPE
         - MAX_EXPORTRUN_EXPIRATION_DAYS=30
+        - BASEMAP_URL
      extra_hosts:
         - "${SITE_NAME}:${SITE_IP}"
      command: echo 'Base box is not used, exiting now'

--- a/eventkit_cloud/settings/prod.py
+++ b/eventkit_cloud/settings/prod.py
@@ -161,6 +161,7 @@ UI_CONFIG = {
     'BANNER_BACKGROUND_COLOR': os.environ.get('BANNER_BACKGROUND_COLOR', ''),
     'BANNER_TEXT_COLOR': os.environ.get('BANNER_TEXT_COLOR', ''),
     'BANNER_TEXT': os.environ.get('BANNER_TEXT', ''),
+    'BASEMAP_URL': os.environ.get('BASEMAP_URL', 'http://tile.openstreetmap.org/{z}/{x}/{y}.png')
 }
 
 if os.environ.get('USE_S3'):

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -287,7 +287,10 @@ export class ExportAOI extends Component {
             layers: [
                 // Order matters here
                 new ol.layer.Tile({
-                    source: new ol.source.OSM()
+                    source: new ol.source.XYZ({
+                        url: this.context.config.BASEMAP_URL,
+                        wrapX: false
+                    })
                 }),
             ],
             target: 'map',
@@ -361,6 +364,10 @@ export class ExportAOI extends Component {
             </div>
         );
     }
+}
+
+ExportAOI.contextTypes = {
+    config: React.PropTypes.object
 }
 
 ExportAOI.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -168,8 +168,11 @@ export class ExportInfo extends React.Component {
 
     }
     _initializeOpenLayers() {
-        var osm = new ol.layer.Tile({
-            source: new ol.source.OSM()
+        var base = new ol.layer.Tile({
+            source: new ol.source.XYZ({
+                url: this.context.config.BASEMAP_URL,
+                wrapX: false
+            })
         })
 
         this._map = new ol.Map({
@@ -179,7 +182,7 @@ export class ExportInfo extends React.Component {
                 pinchRotate: false,
                 mouseWheelZoom: false
             }),
-            layers: [osm],
+            layers: [base],
             target: 'infoMap',
             view: new ol.View({
                 projection: "EPSG:3857",
@@ -406,6 +409,10 @@ function mapDispatchToProps(dispatch) {
         }
 
     }
+}
+
+ExportInfo.contextTypes = {
+    config: React.PropTypes.object
 }
 
 ExportInfo.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
@@ -49,8 +49,11 @@ class ExportSummary extends React.Component {
 
     _initializeOpenLayers() {
 
-        var osm = new ol.layer.Tile({
-            source: new ol.source.OSM()
+        var base = new ol.layer.Tile({
+            source: new ol.source.XYZ({
+                url: this.context.config.BASEMAP_URL,
+                wrapX: false
+            })
         });
 
         this._map = new ol.Map({
@@ -60,7 +63,7 @@ class ExportSummary extends React.Component {
                 pinchRotate: false,
                 mouseWheelZoom: false
             }),
-            layers: [osm],
+            layers: [base],
             target: 'summaryMap',
             view: new ol.View({
                 projection: "EPSG:3857",
@@ -199,7 +202,9 @@ function mapStateToProps(state) {
     }
 }
 
-
+ExportSummary.contextTypes = {
+    config: React.PropTypes.object
+}
 
 ExportSummary.propTypes = {
     geojson:         React.PropTypes.object,

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGridItem.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGridItem.js
@@ -50,7 +50,10 @@ export class DataPackGridItem extends Component {
             target: this.props.run.uid + '_map',
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.OSM()
+                    source: new ol.source.XYZ({
+                        url: this.context.config.BASEMAP_URL,
+                        wrapX: false
+                    })
                 }),
             ],
             view: new ol.View({
@@ -312,6 +315,10 @@ export class DataPackGridItem extends Component {
             </Card>
         )
     }
+}
+
+DataPackGridItem.contextTypes = {
+    config: React.PropTypes.object
 }
 
 DataPackGridItem.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -179,7 +179,10 @@ export class MapView extends Component {
             }),
             layers: [
                 new ol.layer.Tile({
-                    source: new ol.source.OSM({wrapX: false})
+                    source: new ol.source.XYZ({
+                        url: this.context.config.BASEMAP_URL,
+                        wrapX: false
+                    })
                 }),
             ],
             target: 'map',
@@ -657,6 +660,10 @@ export class MapView extends Component {
             </div>
         )      
     }
+}
+
+MapView.contextTypes = {
+    config: React.PropTypes.object
 }
 
 MapView.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
@@ -92,8 +92,11 @@ export class DataCartDetails extends React.Component {
         }
     }
     _initializeOpenLayers() {
-        var osm = new ol.layer.Tile({
-            source: new ol.source.OSM()
+        var base = new ol.layer.Tile({
+            source: new ol.source.XYZ({
+                url: this.context.config.BASEMAP_URL,
+                wrapX: false
+            })
         });
 
         this._map = new ol.Map({
@@ -103,7 +106,7 @@ export class DataCartDetails extends React.Component {
                 pinchRotate: false,
                 mouseWheelZoom: false
             }),
-            layers: [osm],
+            layers: [base],
             target: 'summaryMap',
             view: new ol.View({
                 projection: "EPSG:3857",
@@ -528,6 +531,10 @@ export class DataCartDetails extends React.Component {
 
         )
     }
+}
+
+DataCartDetails.contextTypes = {
+    config: React.PropTypes.object
 }
 
 DataCartDetails.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.js
@@ -72,9 +72,13 @@ describe('MapView component', () => {
     };
 
     const getWrapper = (props) => {
+        const config= {BASEMAP_URL: 'http://my-osm-tile-service/{z}/{x}/{y}.png'};
         return mount(<MapView {...props}/>, {
-            context: {muiTheme},
-            childContextTypes: {muiTheme: React.PropTypes.object}
+            context: {muiTheme, config},
+            childContextTypes: {
+                muiTheme: React.PropTypes.object, 
+                config: React.PropTypes.object
+            }
         });
     }
 
@@ -256,7 +260,7 @@ describe('MapView component', () => {
         const overviewSpy = new sinon.spy(ol.control, 'OverviewMap');
         const interactionSpy = new sinon.spy(ol.interaction, 'defaults');
         const layerSpy = new sinon.spy(ol.layer, 'Tile');
-        const osmSpy = new sinon.spy(ol.source, 'OSM');
+        const xyzSpy = new sinon.spy(ol.source, 'XYZ');
         const viewSpy = new sinon.spy(ol, 'View');
         expect(inheritSpy.notCalled).toBe(true);
         wrapper.instance().initMap();
@@ -268,7 +272,7 @@ describe('MapView component', () => {
         expect(overviewSpy.calledOnce).toBe(true);
         expect(interactionSpy.calledOnce).toBe(true);
         expect(layerSpy.calledOnce).toBe(true);
-        expect(osmSpy.calledOnce).toBe(true);
+        expect(xyzSpy.calledOnce).toBe(true);
         expect(viewSpy.calledOnce).toBe(true);
         inheritSpy.restore();
         mapSpy.restore();
@@ -276,7 +280,7 @@ describe('MapView component', () => {
         zoomSpy.restore();
         interactionSpy.restore();
         layerSpy.restore();
-        osmSpy.restore();
+        xyzSpy.restore();
         viewSpy.restore();
     });
 

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,10 @@ By default EventKit will use geonames.org. However it also supports pelias. If w
 <pre>GEOCODING_API_URL = 'http://my-pelias.com/api/v1'</pre>
 <pre>GEOCODING_API_TYPE = 'pelias'</pre>
 
+#### Basemap URL
+To set the application basemap add:
+<pre>BASEMAP_URL=http://my-tile-service.com/{z}/{x}/{y}.png</pre>
+
 ### Tests
 To run tests:
 <pre>docker-compose run --rm -e COVERAGE=True eventkit python manage.py test eventkit_cloud</pre>


### PR DESCRIPTION
This pr allows you to specify a xyz tile url env var for the basemap. If no env var is provided it will default to the public osm tile source