### PR TITLE
Cleanup Status & Download page on small screen sizes.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
@@ -129,7 +129,7 @@ class ExportSummary extends React.Component {
                                 <td className={styles.tdData}>{this.props.datapackDescription}</td>
                             </tr>
                             <tr>
-                                <td className={styles.tdHeading}>Project/Category</td>
+                                <td className={styles.tdHeading}>Project&nbsp;/ Category</td>
                                 <td className={styles.tdData}>{this.props.projectName}</td>
                             </tr>
                             <tr>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
@@ -224,7 +224,7 @@ export class DataCartDetails extends React.Component {
         });
 
         const styles = {
-            tdHeader: {backgroundColor: '#f8f8f8', padding: '10px', fontWeight: 'bold', width: '15%'},
+            tdHeader: {backgroundColor: '#f8f8f8', padding: '10px', fontWeight: 'bold', width: '140px'},
             tdData: {backgroundColor: '#f8f8f8', padding: '10px', color: '#8b9396', wordWrap: 'break-word'},
             subHeading: {fontSize: '16px', alignContent: 'flex-start', color: 'black', paddingBottom: '10px', paddingTop: '30px', fontWeight: 'bold'},
             textField: {fontSize: '14px', height: '36px', width: '0px', display:'inlineBlock'},
@@ -454,7 +454,7 @@ export class DataCartDetails extends React.Component {
                             <td style={styles.tdData}>{this.props.cartDetails.job.description}</td>
                         </tr>
                         <tr>
-                            <td style={styles.tdHeader}>Project/Category</td>
+                            <td style={styles.tdHeader}>Project&nbsp;/ Category</td>
                             <td style={styles.tdData}>{this.props.cartDetails.job.event}</td>
                         </tr>
                         <tr>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.js
@@ -136,12 +136,7 @@ export class DataPackDetails extends React.Component {
     }
 
     getToggleCellWidth() {
-        if(window.innerWidth <= 767) {
-            return '50px';
-        }
-        else {
-            return '70px';
-        }
+        return '70px';
     }
 
     getCheckboxStatus() {

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
@@ -228,12 +228,7 @@ export class ProviderRow extends React.Component {
     }
 
     getToggleCellWidth() {
-        if(window.innerWidth <= 767) {
-            return '30px';
-        }
-        else {
-            return '50px';
-        }
+        return '50px';
     }
 
     handleProviderClose = () => {

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
@@ -131,8 +131,8 @@ export class StatusDownload extends React.Component {
                 backgroundRepeat: 'repeat repeat'
             },
             content: {
-                paddingTop:'30px',
-                paddingBottom: '30px',
+                paddingTop: marginPadding,
+                paddingBottom: marginPadding,
                 paddingLeft: marginPadding,
                 paddingRight: marginPadding,
                 margin: 'auto',

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartDetails.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartDetails.spec.js
@@ -72,7 +72,7 @@ describe('DataCartDetails component', () => {
         table = wrapper.find('table').at(6);
         expect(table.find('tr').at(0).find('td').first().text()).toEqual('Description');
         expect(table.find('tr').at(0).find('td').last().text()).toEqual('test');
-        expect(table.find('tr').at(1).find('td').first().text()).toEqual('Project/Category');
+        expect(table.find('tr').at(1).find('td').first().text().replace(/\s/g, ' ')).toEqual('Project / Category');
         expect(table.find('tr').at(1).find('td').last().text()).toEqual('test');
         expect(table.find('tr').at(2).find('td').first().text()).toEqual('Data Sources');
         expect(table.find('tr').at(2).find('td').last().text()).toEqual('OpenStreetMap Data (Themes)');

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackDetails.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackDetails.spec.js
@@ -100,29 +100,6 @@ describe('DataPackDetails component', () => {
         expect(wrapper.instance().getTableCellWidth()).toEqual('120px');
     });
 
-    it('getToggleCellWidth should return the pixel string for table width based on window width', () => {
-        const props = getProps();
-        const wrapper = getWrapper(props);
-
-        window.resizeTo(700, 800);
-        expect(window.innerWidth).toEqual(700);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('50px');
-
-        window.resizeTo(800, 900);
-        expect(window.innerWidth).toEqual(800);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('70px');
-
-        window.resizeTo(1000, 600);
-        expect(window.innerWidth).toEqual(1000);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('70px');
-
-        window.resizeTo(1200, 600);
-        expect(window.innerWidth).toEqual(1200);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('70px');
-    });
-
-
-
     it('should call checkAll when the checkbox is checked/unchecked', () => {
         const props = getProps();
         const checkAllSpy = new sinon.spy(DataPackDetails.prototype, 'checkAll');

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
@@ -178,28 +178,6 @@ describe('ProviderRow component', () => {
         expect(wrapper.instance().getTableCellWidth()).toEqual('120px');
     });
 
-    it('getToggleCellWidth should return the pixel string for table width based on window width', () => {
-        const props = getProps();
-        const wrapper = getWrapper(props);
-
-        window.resizeTo(700, 800);
-        expect(window.innerWidth).toEqual(700);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('30px');
-
-        window.resizeTo(800, 900);
-        expect(window.innerWidth).toEqual(800);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('50px');
-
-        window.resizeTo(1000, 600);
-        expect(window.innerWidth).toEqual(1000);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('50px');
-
-        window.resizeTo(1200, 600);
-        expect(window.innerWidth).toEqual(1200);
-        expect(wrapper.instance().getToggleCellWidth()).toEqual('50px');
-    });
-
-
     it('should call componentWillMount and set the row and count state', () => {
         const props = getProps();
         const mountSpy = new sinon.spy(ProviderRow.prototype, 'componentWillMount');


### PR DESCRIPTION
With this update there should be no overlap of elements on the Status & Download page down to the minimum screen width (375px). It also fixes an issue in that same page where table rows in Download Options would overflow horizontally at the minimum screen width. 

There's still an issue with the "Download Selected" button label overflowing vertically on small screen widths, but I was told to ignore that for now since it will be changing in the near future.

![selection_004](https://user-images.githubusercontent.com/3220897/29894399-0588475c-8d8a-11e7-8dea-dc8253bb0d5b.png)