### PR TITLE
Set max lengths on create datapack text inputs.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -239,6 +239,7 @@ export class ExportInfo extends React.Component {
                                 style={{backgroundColor: 'whitesmoke', width: '100%',  marginTop: '15px'}}
                                 inputStyle={{fontSize: '16px', paddingLeft: '5px'}}
                                 hintStyle={{fontSize: '16px', paddingLeft: '5px'}}
+                                maxLength={100}
                             />
                             <TextField
                                 underlineStyle={style.underlineStyle}
@@ -252,6 +253,7 @@ export class ExportInfo extends React.Component {
                                 style={{backgroundColor: 'whitesmoke', width: '100%', marginTop: '15px'}}
                                 textareaStyle={{fontSize: '16px', paddingLeft: '5px'}}
                                 hintStyle={{fontSize: '16px', paddingLeft: '5px'}}
+                                maxLength={1000}
                             />
                             <TextField
                                 underlineStyle={style.underlineStyle}
@@ -263,6 +265,7 @@ export class ExportInfo extends React.Component {
                                 style={{backgroundColor: 'whitesmoke', width: '100%',  marginTop: '15px'}}
                                 inputStyle={{fontSize: '16px', paddingLeft: '5px'}}
                                 hintStyle={{fontSize: '16px', paddingLeft: '5px'}}
+                                maxLength={100}
                             />
                             <div className={styles.checkbox}>
                                 <Checkbox


### PR DESCRIPTION
In step 2 of create datapack, limited datapack and project names to 100 characters, and limited description to 1000 characters.