### PR TITLE
Don't allow arbitary input lengths.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
@@ -132,7 +132,7 @@ export class DataPackPage extends React.Component {
         params += status.length ? `&status=${status.join(',')}` : '';
         params += minDate;
         params += maxDate;
-        params += this.state.search ? `&search_term=${this.state.search}` : '';
+        params += this.state.search ? `&search_term=${this.state.search.slice(0, 1000)}` : '';
         params += providers.length ? `&providers=${providers.join(',')}` : '';
         return this.props.getRuns(params, this.state.geojson_geometry);
     }

--- a/eventkit_cloud/ui/static/ui/app/components/MapTools/SearchAOIToolbar.js
+++ b/eventkit_cloud/ui/static/ui/app/components/MapTools/SearchAOIToolbar.js
@@ -41,6 +41,8 @@ export class SearchAOIToolbar extends Component {
     }
 
     handleChange(e) {
+        e = e.slice(0, 1000);
+
         // If 2 or more characters are entered then make request for suggested names.
         if(e.length >= 2) {
             this.props.getGeocode(e);
@@ -55,6 +57,8 @@ export class SearchAOIToolbar extends Component {
     }
 
     handleEnter(e) {
+        e = e.slice(0, 1000);
+
         this.setState({suggestions: []});
         if (e.length > 0) {
             if(this.props.handleSearch(e[0])){

--- a/eventkit_cloud/ui/static/ui/app/containers/loginContainer.js
+++ b/eventkit_cloud/ui/static/ui/app/containers/loginContainer.js
@@ -108,6 +108,7 @@ export class Form extends React.Component {
                     placeholder="Username"
                     style={styles.input}
                     type="text"
+                    maxLength="150"
                 />
                 <input 
                     id="password"
@@ -116,6 +117,7 @@ export class Form extends React.Component {
                     onChange={this.onChange}
                     style={styles.input}
                     type="password"
+                    maxLength="256"
                 />
                 <RaisedButton 
                     style={{margin: '30px auto', width: '150px'}}


### PR DESCRIPTION
Added maxlength props to login inputs. The autocomplete and typeahead components don't support maxlength, and neither return events in their onInputChange() callbacks, so I just enforced a character limit of 1000 for them under the hood. So you can continue entering input in those fields beyond the limit - it will just be ignored past the 1000 character point. After that point there shouldn't be any results from them anyways, so I don't think it will matter that the input after that point is ignored.