### PR TITLE
use dialog instead of linking to account page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/LicenseRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/LicenseRow.js
@@ -1,0 +1,120 @@
+import React, {PropTypes, Component} from 'react'
+import {TableRow, TableRowColumn} from 'material-ui/Table';
+import BaseDialog from '../BaseDialog';
+
+export class LicenseRow extends React.Component {
+    constructor(props) {
+        super(props)
+        this.setLicenseOpen = this.setLicenseOpen.bind(this);
+        this.handleLicenseClose = this.handleLicenseClose.bind(this);
+        this.state = {
+            licenseDialogOpen: false,
+        }
+    }
+
+
+    getTextFontSize() {
+        if(window.innerWidth <= 575) {
+            return '10px';
+        }
+        else if (window.innerWidth <= 767) {
+            return '11px';
+        }
+        else if (window.innerWidth <= 991) {
+            return '12px';
+        }
+        else if(window.innerWidth <= 1199) {
+            return '13px';
+        }
+        else {
+            return '14px';
+        }
+    }
+
+    getTableCellWidth() {
+        if(window.innerWidth <= 767) {
+            return '80px';
+        }
+        else {
+            return '120px';
+        }
+    }
+
+    setLicenseOpen() {
+        this.setState({licenseDialogOpen: true});
+    }
+
+    handleLicenseClose() {
+        this.setState({licenseDialogOpen: false});
+    }
+
+
+    render() {
+        const textFontSize = this.getTextFontSize();
+        const tableCellWidth = this.getTableCellWidth();
+        const toggleCellWidth = '50px'
+        
+        return (
+            <TableRow selectable={false} style={{height: '20px'}} displayBorder={true}>
+                <TableRowColumn style={{paddingRight: '12px', paddingLeft: '12px', width: '44px'}}>
+                </TableRowColumn>
+                <TableRowColumn  style={{paddingRight: '12px', paddingLeft: '12px', fontSize: '12px'}}>
+                    <i>
+                        Use of this data is governed by <a 
+                                                            onClick={this.setLicenseOpen}
+                                                            style={{cursor: 'pointer', color: '#4598bf'}}
+                                                        >
+                                                            {this.props.name}
+                                                        </a>
+                    </i>
+                    <BaseDialog
+                        show={this.state.licenseDialogOpen}
+                        title={this.props.name}
+                        onClose={this.handleLicenseClose}
+                    >
+                        <div style={{whiteSpace: 'pre-wrap'}}>{this.props.text}</div>
+                    </BaseDialog>
+                </TableRowColumn>
+                <TableRowColumn style={{
+                    width: tableCellWidth,
+                    paddingRight: '0px',
+                    paddingLeft: '0px',
+                    textAlign: 'center',
+                    fontSize: textFontSize
+                }}>
+                </TableRowColumn>
+                <TableRowColumn style={{
+                    width: tableCellWidth,
+                    paddingRight: '10px',
+                    paddingLeft: '10px',
+                    textAlign: 'center',
+                    fontSize: textFontSize,
+                    fontWeight: 'bold'
+                }}>
+                </TableRowColumn>
+                <TableRowColumn style={{
+                    paddingRight: '0px',
+                    paddingLeft: '0px',
+                    width: '20px',
+                    textAlign: 'center',
+                    fontSize: textFontSize
+                }}></TableRowColumn>
+                <TableRowColumn style={{
+                    paddingRight: '0px',
+                    paddingLeft: '0px',
+                    width: toggleCellWidth,
+                    textAlign: 'center',
+                    fontSize: textFontSize
+                }}></TableRowColumn>
+            </TableRow>
+        )
+    }
+}
+
+LicenseRow.propTypes = {
+    name: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+}
+
+export default LicenseRow;
+

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
@@ -21,6 +21,7 @@ import CustomScrollbar from '../CustomScrollbar';
 import TaskError from './TaskError';
 import ProviderError from './ProviderError';
 import BaseDialog from '../BaseDialog';
+import LicenseRow from './LicenseRow';
 
 export class ProviderRow extends React.Component {
     constructor(props) {
@@ -85,9 +86,6 @@ export class ProviderRow extends React.Component {
             downloadUrls.push(a.result.url);
         })
         downloadUrls.forEach((value, idx) => {
-            // setTimeout(() => {
-            //     window.location.href = value;
-            // }, idx * 1000);
             window.open(value, '_blank');
         });
     }
@@ -226,10 +224,6 @@ export class ProviderRow extends React.Component {
         }
     }
 
-    getToggleCellWidth() {
-        return '50px';
-    }
-
     handleProviderClose = () => {
         this.setState({providerDialogOpen: false});
     };
@@ -240,66 +234,19 @@ export class ProviderRow extends React.Component {
         this.setState({providerDesc, providerDialogOpen: true});
     };
 
-
     render() {
         const style = {
             textDecoration: 'underline'
         }
         const textFontSize = this.getTextFontSize();
         const tableCellWidth = this.getTableCellWidth();
-        const toggleCellWidth = this.getToggleCellWidth();
+        const toggleCellWidth = '50px';
         const {provider, ...rowProps} = this.props;
-
         let propsProvider = this.props.providers.find(x => x.slug === this.props.provider.slug);
-        let licenseText = '';
-        let licenseData;
-        if (propsProvider.license != null) {
-            licenseText = <i>Use of this data is governed by the <a href='../account'>{propsProvider.license.name}</a></i>;
-            licenseData = <TableRow selectable={false} style={{height: '20px'}} displayBorder={true}>
-                    <TableRowColumn style={{paddingRight: '12px', paddingLeft: '12px', width: '44px'}}>
-
-                    </TableRowColumn>
-                    <TableRowColumn  style={{paddingRight: '12px', paddingLeft: '12px', fontSize: '12px'}}>
-                        {licenseText}
-                    </TableRowColumn>
-                    <TableRowColumn style={{
-                        width: tableCellWidth,
-                        paddingRight: '0px',
-                        paddingLeft: '0px',
-                        textAlign: 'center',
-                        fontSize: textFontSize
-                    }}>
-
-                    </TableRowColumn>
-                    <TableRowColumn style={{
-                        width: tableCellWidth,
-                        paddingRight: '10px',
-                        paddingLeft: '10px',
-                        textAlign: 'center',
-                        fontSize: textFontSize,
-                        fontWeight: 'bold'
-                    }}>
-
-                    </TableRowColumn>
-                    <TableRowColumn style={{
-                        paddingRight: '0px',
-                        paddingLeft: '0px',
-                        width: '20px',
-                        textAlign: 'center',
-                        fontSize: textFontSize
-                    }}></TableRowColumn>
-                    <TableRowColumn style={{
-                        paddingRight: '0px',
-                        paddingLeft: '0px',
-                        width: toggleCellWidth,
-                        textAlign: 'center',
-                        fontSize: textFontSize
-                    }}></TableRowColumn>
-                </TableRow>
-        }
-
-
-
+        const licenseData = propsProvider.license ? 
+            <LicenseRow name={propsProvider.license.name} text={propsProvider.license.text}/>
+            : 
+            null;
         let menuItems = [];
         let cancelMenuDisabled;
         if(this.props.provider.status == 'PENDING' || this.props.provider.status == 'RUNNING') {
@@ -352,14 +299,11 @@ export class ProviderRow extends React.Component {
                 ))}
 
             </TableBody>
-
         }
         else{
             tableData = <TableBody/>
         }
 
-
-        
         return (
             <Table key={this.props.provider.uid}
                    style={{width:'100%', backgroundColor:this.props.backgroundColor}}
@@ -424,7 +368,6 @@ export class ProviderRow extends React.Component {
                             </IconButton>
                         </TableHeaderColumn>
                     </TableRow>
-
                 </TableHeader>
                             {tableData}
             </Table>

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/LicenseRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/LicenseRow.spec.js
@@ -1,0 +1,105 @@
+import React from 'react';
+import sinon from 'sinon';
+import {mount, shallow} from 'enzyme';
+import LicenseRow from '../../components/StatusDownloadPage/LicenseRow';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import {TableRow, TableRowColumn} from 'material-ui/Table';
+import BaseDialog from '../../components/BaseDialog';
+
+describe('LicenseRow component', () => {
+    const muiTheme = getMuiTheme();
+
+    const getProps = () => {
+        return  {
+           name: 'test name',
+           text: 'test text'
+        }
+    };
+
+    const getWrapper = (props) => {
+        return mount(<LicenseRow {...props}/>, {
+            context: {muiTheme},
+            childContextTypes: {
+                muiTheme: React.PropTypes.object
+            }
+        });
+    };
+
+    it('should render elements', () => {
+        let props = getProps();
+        const wrapper = getWrapper(props);
+        expect(wrapper.find(TableRow)).toHaveLength(1);
+        expect(wrapper.find(TableRowColumn)).toHaveLength(6);
+        expect(wrapper.find(BaseDialog)).toHaveLength(1);
+        expect(wrapper.find('i')).toHaveLength(1);
+        expect(wrapper.find('i').text()).toEqual('Use of this data is governed by test name');
+    });
+
+    it('getTextFontSize should return the font string for table text based on window width', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+
+        window.resizeTo(500, 600);
+        expect(window.innerWidth).toEqual(500);
+        expect(wrapper.instance().getTextFontSize()).toEqual('10px');
+
+        window.resizeTo(700, 800);
+        expect(window.innerWidth).toEqual(700);
+        expect(wrapper.instance().getTextFontSize()).toEqual('11px');
+
+        window.resizeTo(800, 900);
+        expect(window.innerWidth).toEqual(800);
+        expect(wrapper.instance().getTextFontSize()).toEqual('12px');
+
+        window.resizeTo(1000, 600);
+        expect(window.innerWidth).toEqual(1000);
+        expect(wrapper.instance().getTextFontSize()).toEqual('13px');
+
+        window.resizeTo(1200, 600);
+        expect(window.innerWidth).toEqual(1200);
+        expect(wrapper.instance().getTextFontSize()).toEqual('14px');
+    });
+
+    it('getTableCellWidth should return the pixel string for table width based on window width', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+
+        window.resizeTo(700, 800);
+        expect(window.innerWidth).toEqual(700);
+        expect(wrapper.instance().getTableCellWidth()).toEqual('80px');
+
+        window.resizeTo(800, 900);
+        expect(window.innerWidth).toEqual(800);
+        expect(wrapper.instance().getTableCellWidth()).toEqual('120px');
+
+        window.resizeTo(1000, 600);
+        expect(window.innerWidth).toEqual(1000);
+        expect(wrapper.instance().getTableCellWidth()).toEqual('120px');
+
+        window.resizeTo(1200, 600);
+        expect(window.innerWidth).toEqual(1200);
+        expect(wrapper.instance().getTableCellWidth()).toEqual('120px');
+    });
+
+    it('setLicenseOpen should set license dialog to open', () => {
+        const props = getProps();
+        const stateSpy = new sinon.spy(LicenseRow.prototype, 'setState');
+        const wrapper = shallow(<LicenseRow {...props}/>);
+        expect(stateSpy.called).toBe(false);
+        wrapper.instance().setLicenseOpen()
+        expect(stateSpy.calledOnce).toBe(true);
+        expect(stateSpy.calledWith({licenseDialogOpen: true})).toBe(true);
+        stateSpy.restore();
+    });
+
+    it('handleProviderClose should set the provider dialog to closed', () => {
+        const props = getProps();
+        const stateSpy = new sinon.spy(LicenseRow.prototype, 'setState');
+        const wrapper = shallow(<LicenseRow {...props}/>);
+        expect(stateSpy.called).toBe(false);
+        wrapper.instance().handleLicenseClose();
+        expect(stateSpy.calledOnce).toBe(true);
+        expect(stateSpy.calledWith({licenseDialogOpen: false})).toBe(true);
+        stateSpy.restore();
+    });
+});

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
@@ -11,13 +11,15 @@ import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColu
 import Checkbox from 'material-ui/Checkbox';
 import NavigationMoreVert from 'material-ui/svg-icons/navigation/more-vert';
 import ArrowUp from 'material-ui/svg-icons/hardware/keyboard-arrow-up';
-import Warning from 'material-ui/svg-icons/alert/warning'
-import Check from 'material-ui/svg-icons/navigation/check'
+import Warning from 'material-ui/svg-icons/alert/warning';
+import Check from 'material-ui/svg-icons/navigation/check';
+import CloudDownload from 'material-ui/svg-icons/file/cloud-download';
 import LinearProgress from 'material-ui/LinearProgress';
 import '../../components/tap_events';
 import ProviderError from '../../components/StatusDownloadPage/ProviderError';
 import TaskError from '../../components/StatusDownloadPage/TaskError';
 import BaseDialog from '../../components/BaseDialog';
+import LicenseRow from '../../components/StatusDownloadPage/LicenseRow';
 
 describe('ProviderRow component', () => {
 
@@ -95,6 +97,7 @@ describe('ProviderRow component', () => {
         expect(wrapper.find(IconButton)).toHaveLength(2);
         expect(wrapper.find(IconButton).find(ArrowUp)).toHaveLength(1);
         expect(wrapper.find(MenuItem)).toHaveLength(0);
+        expect(wrapper.find(BaseDialog)).toHaveLength(1);
     });
 
     it('should render the cancel menu item if the task is pending/running and the cancel menu item should call onProviderCancel', () => {
@@ -117,6 +120,7 @@ describe('ProviderRow component', () => {
         expect(wrapper.find(TableRowColumn)).toHaveLength(12);
         expect(wrapper.find(Checkbox)).toHaveLength(1);
         expect(wrapper.find(TableBody)).toHaveLength(1);
+        expect(wrapper.find(LicenseRow)).toHaveLength(1);
     });
 
     it('should handle summing up the file sizes', () => {
@@ -306,22 +310,51 @@ describe('ProviderRow component', () => {
         expect(wrapper.instance().getProviderStatus('')).toEqual('');
     });
 
-    it('getTaskLink should get called with correct data', () => {
+    it('getTaskLink should return a "span" element', () => {
         const props = getProps();
-        const getTaskLink = new sinon.spy(ProviderRow.prototype, 'getTaskLink');
         const wrapper = getWrapper(props);
-        wrapper.instance().getTaskLink(props.provider.tasks[0]);
-        expect(getTaskLink.calledOnce).toBe(true);
-        expect(getTaskLink.calledWith(props.provider.tasks[0])).toBe(true);
+        const task = {result: {}, name: 'test name'};
+        const link = wrapper.instance().getTaskLink(task);
+        const elem = shallow(link);
+        expect(elem.is('span')).toBe(true);
+        expect(elem.text()).toEqual('test name');
     });
 
-    it('getTaskDownloadIcon should be called with correct data', () => {
+    it('getTaskLink should return a "a" element', () => {
         const props = getProps();
-        const getTaskIcon = new sinon.spy(ProviderRow.prototype, 'getTaskDownloadIcon');
         const wrapper = getWrapper(props);
-        wrapper.instance().getTaskDownloadIcon(props.provider.tasks[0]);
-        expect(getTaskIcon.calledOnce).toBe(true);
-        expect(getTaskIcon.calledWith(props.provider.tasks[0])).toBe(true);
+        const task = {result: {url: 'test-url.io'}, name: 'test name'};
+        const link = wrapper.instance().getTaskLink(task);
+        const elem = shallow(link);
+        expect(elem.is('a')).toBe(true);
+        expect(elem.props().href).toEqual('test-url.io');
+        expect(elem.text()).toEqual('test name')
+    });
+
+    it('getTaskDownloadIcon should return a disabled icon', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        const task = {result: {}};
+        const icon = wrapper.instance().getTaskDownloadIcon(task);
+        const elem = mount(icon, {
+            context: {muiTheme},
+            childContextTypes: {muiTheme: React.PropTypes.object}
+        });
+        expect(elem.is(CloudDownload)).toBe(true);
+        expect(elem.props().onClick).toBe(undefined);
+    });
+
+    it('getTaskDownloadIcon should return a icon with click handler', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        const task = {result: {url: 'test-url.io'}};
+        const icon = wrapper.instance().getTaskDownloadIcon(task);
+        const elem = mount(icon, {
+            context: {muiTheme},
+            childContextTypes: {muiTheme: React.PropTypes.object}
+        });
+        expect(elem.is(CloudDownload)).toBe(true);
+        expect(elem.props().onClick).not.toBe(undefined);
     });
 
     it('getProviderLink should be called with the icon from a given provider', () => {


### PR DESCRIPTION
This pr adds a dialog for the provider license text instead of navigating the user to the account page.
![image](https://user-images.githubusercontent.com/16799449/30077449-e00b1bb6-9249-11e7-9cbf-8ac0a6a52729.png)
