### PR TITLE
Fix bottom padding in DataPack Library page.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -606,10 +606,10 @@ export class MapView extends Component {
             :
                 {
                     width: '70%', 
-                    height: window.innerHeight - 236, 
+                    height: window.innerHeight - 241,
                     display: 'inline-block', 
                     overflow: 'hidden', 
-                    padding: '0px 10px 10px 3px', 
+                    padding: '0px 10px 0px 3px',
                     position: 'relative'
                 },
             list: window.innerWidth < 768 ?
@@ -618,7 +618,7 @@ export class MapView extends Component {
                 }
             :
                 {
-                    height: window.innerHeight - 236, 
+                    height: window.innerHeight - 241,
                     width: '30%', 
                     display: 'inline-block'
                 },


### PR DESCRIPTION
Made the bottom padding consistent in the DataPack Library page.

![selection_011](https://user-images.githubusercontent.com/3220897/30085278-9091831c-924a-11e7-9a66-f10596a42ea8.png)
