### PR TITLE
120 refactor export info

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/actions/exportsActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/exportsActions.js
@@ -9,19 +9,6 @@ export function createExportRequest(exportData) {
     }
 }
 
-export function exportInfoDone() {
-    return {
-        type: types.EXPORT_INFO_DONE,
-        setExportPackageFlag: true
-    }
-}
-export function exportInfoNotDone() {
-    return {
-        type: types.EXPORT_INFO_NOTDONE,
-        setExportPackageFlag: false
-    }
-}
-
 export function updateAoiInfo(geojson, geomType, title, description,) {
     return {
         type: types.UPDATE_AOI_INFO,
@@ -31,16 +18,10 @@ export function updateAoiInfo(geojson, geomType, title, description,) {
         description,
     }
 }
-export function updateExportInfo(exportName, datapackDescription, projectName, makePublic, providers, area_str, layers) {
+export function updateExportInfo(exportInfo) {
     return {
         type: types.UPDATE_EXPORT_INFO,
-        exportName : exportName,
-        datapackDescription,
-        projectName,
-        makePublic,
-        providers,
-        area_str,
-        layers,
+        exportInfo: exportInfo
     }
 }
 

--- a/eventkit_cloud/ui/static/ui/app/components/BreadcrumbStepper.js
+++ b/eventkit_cloud/ui/static/ui/app/components/BreadcrumbStepper.js
@@ -22,7 +22,6 @@ export class BreadcrumbStepper extends React.Component {
         this.handleNext = this.handleNext.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
         this.handlePrev = this.handlePrev.bind(this);
-        this.incrementStepper = this.incrementStepper.bind(this);
         this.state = {
             stepIndex: 0,
         };
@@ -82,11 +81,6 @@ export class BreadcrumbStepper extends React.Component {
         this.setState({stepIndex: stepIndex + 1});
     };
 
-    incrementStepper() {
-        const {stepIndex} = this.state;
-        this.setState({stepIndex: stepIndex + 1});
-    }
-
     handlePrev() {
         const {stepIndex} = this.state;
         if (stepIndex > 0) {
@@ -130,7 +124,6 @@ export class BreadcrumbStepper extends React.Component {
                 return <ExportAOI/>;
             case 1:
                 return <ExportInfo providers={this.props.providers}
-                                   incrementStepper={this.incrementStepper}
                                    handlePrev={this.handlePrev}/>
             case 2:
                 return <ExportSummary/>

--- a/eventkit_cloud/ui/static/ui/app/components/BreadcrumbStepper.js
+++ b/eventkit_cloud/ui/static/ui/app/components/BreadcrumbStepper.js
@@ -10,7 +10,7 @@ import ExportAOI from './CreateDataPack/ExportAOI'
 import ExportInfo from './CreateDataPack/ExportInfo'
 import ExportSummary from './CreateDataPack/ExportSummary'
 import { createExportRequest, getProviders, stepperNextDisabled,
-    stepperNextEnabled, exportInfoDone, submitJob, clearAoiInfo, clearExportInfo, clearJobInfo} from '../actions/exportsActions'
+    stepperNextEnabled, submitJob, clearAoiInfo, clearExportInfo, clearJobInfo} from '../actions/exportsActions'
 import { setDatacartDetailsReceived, getDatacartDetails} from '../actions/statusDownloadActions'
 
 const isEqual = require('lodash/isEqual');
@@ -79,12 +79,7 @@ export class BreadcrumbStepper extends React.Component {
 
     handleNext() {
         const {stepIndex} = this.state;
-        if (stepIndex == 1) {
-            this.props.setExportInfoDone();
-        }
-        else {
-            this.setState({stepIndex: stepIndex + 1});
-        }
+        this.setState({stepIndex: stepIndex + 1});
     };
 
     incrementStepper() {
@@ -276,7 +271,6 @@ BreadcrumbStepper.propTypes = {
     setNextDisabled: React.PropTypes.func,
     setNextEnabled: React.PropTypes.func,
     setDatacartDetailsReceived: React.PropTypes.func,
-    setExportInfoDone: React.PropTypes.func,
     clearAoiInfo: React.PropTypes.func,
     clearExportInfo: React.PropTypes.func,
     clearJobInfo: React.PropTypes.func,
@@ -311,9 +305,6 @@ function mapDispatchToProps(dispatch) {
         },
         setNextEnabled: () => {
             dispatch(stepperNextEnabled());
-        },
-        setExportInfoDone: () => {
-            dispatch(exportInfoDone());
         },
         clearAoiInfo: () => {
             dispatch(clearAoiInfo());

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -27,6 +27,7 @@ export class ExportInfo extends React.Component {
         this.onProjectChange = this.onProjectChange.bind(this);        
         this.screenSizeUpdate = this.screenSizeUpdate.bind(this);
         this.hasRequiredFields = this.hasRequiredFields.bind(this);
+        this._initializeOpenLayers = this._initializeOpenLayers.bind(this);
     }
 
     componentDidMount() {        
@@ -132,7 +133,6 @@ export class ExportInfo extends React.Component {
                 }
             }
         }
-        console.log(providers);
         // update the state with the new array of options
         this.props.updateExportInfo({
             ...this.props.exportInfo,
@@ -184,7 +184,7 @@ export class ExportInfo extends React.Component {
                 url: this.context.config.BASEMAP_URL,
                 wrapX: false
             })
-        })
+        });
 
         this._map = new ol.Map({
             interactions: ol.interaction.defaults({
@@ -202,24 +202,22 @@ export class ExportInfo extends React.Component {
                 minZoom: 2,
                 maxZoom: 22,
             })
-        })
-        const source = new ol.source.Vector()
-        const geojson = new ol.format.GeoJSON()
+        });
+        const source = new ol.source.Vector();
+        const geojson = new ol.format.GeoJSON();
         const feature = geojson.readFeature(this.props.geojson.features[0], {
             'featureProjection': 'EPSG:3857',
             'dataProjection': 'EPSG:4326'
-        })
+        });
         source.addFeature(feature)
         const layer = new ol.layer.Vector({
             source: source,
-        })
-        const area = feature.getGeometry().getArea() / 1000000
-        const area_str = numeral(area).format('0,0')
+        });
 
-        this._map.addLayer(layer)
-        this._map.getView().fit(source.getExtent(), this._map.getSize())
-
+        this._map.addLayer(layer);
+        this._map.getView().fit(source.getExtent(), this._map.getSize());
     }
+
     render() {
         const style ={
             underlineStyle: {
@@ -422,10 +420,6 @@ ExportInfo.propTypes = {
     updateExportInfo: PropTypes.func.isRequired,
     setNextDisabled: PropTypes.func.isRequired,
     setNextEnabled: PropTypes.func.isRequired
-}
-
-ExportInfo.childContextTypes = {
-    muiTheme: React.PropTypes.object.isRequired,
 }
 
 export default connect(

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
@@ -225,7 +225,14 @@ function mapDispatchToProps(dispatch) {
         },
         cloneExport: (cartDetails, providerArray) => {
             dispatch(updateAoiInfo({type: "FeatureCollection", features: [cartDetails.job.extent]}, 'Polygon', 'Custom Polygon', 'Box'));
-            dispatch(updateExportInfo(cartDetails.job.name, cartDetails.job.description, cartDetails.job.event, cartDetails.job.published, providerArray, 'Geopackage'))
+            dispatch(updateExportInfo({
+                exportName: cartDetails.job.name, 
+                datapackDescription: cartDetails.job.description, 
+                projectName: cartDetails.job.event, 
+                makePublic: cartDetails.job.published, 
+                providers: providerArray, 
+                layers: 'Geopackage'
+            }))
             browserHistory.push('/create/')
         },
         cancelProviderTask:(providerUid) => {

--- a/eventkit_cloud/ui/static/ui/app/reducers/exportsReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/exportsReducer.js
@@ -24,17 +24,6 @@ export function stepperReducer(state = initialState.stepperNextEnabled, action) 
     }
 }
 
-export function startExportPackageReducer(state = initialState.setExportPackageFlag, action) {
-    switch(action.type) {
-        case types.EXPORT_INFO_DONE:
-            return true;
-        case types.EXPORT_INFO_NOTDONE:
-            return false;
-        default:
-            return state;
-    }
-}
-
 export function exportAoiInfoReducer(state = initialState.aoiInfo, action) {
     switch(action.type) {
         case types.UPDATE_AOI_INFO:
@@ -60,13 +49,8 @@ export function exportInfoReducer(state = initialState.exportInfo, action) {
     switch(action.type) {
         case types.UPDATE_EXPORT_INFO:
             return {
-                exportName: action.exportName,
-                datapackDescription: action.datapackDescription,
-                projectName: action.projectName,
-                makePublic: action.makePublic,
-                providers: action.providers,
-                area_str: action.area_str,
-                layers: action.layers,
+                ...state,
+                ...action.exportInfo
             };
         case types.CLEAR_EXPORT_INFO:
             return {

--- a/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
@@ -55,11 +55,10 @@ export default {
         makePublic: false,
         providers: [],
         area_str: '',
-        layers: '',
+        layers: 'Geopackage',
     },
     providers: [],
     stepperNextEnabled: false,
-    setExportPackageFlag: false,
     datacartDetailsReceived:false,
     datacartDetails: {
         fetching: false,

--- a/eventkit_cloud/ui/static/ui/app/reducers/rootReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/rootReducer.js
@@ -1,5 +1,4 @@
 import {combineReducers} from 'redux'
-import { reducer as reduxFormReducer } from 'redux-form'
 import userReducer from './userReducer'
 import { routerReducer } from 'react-router-redux'
 import {exportJobsReducer, exportBboxReducer, exportAoiInfoReducer, exportInfoReducer, getProvidersReducer, drawerMenuReducer, stepperReducer, startExportPackageReducer, submitJobReducer} from './exportsReducer';
@@ -21,7 +20,6 @@ const rootReducer = combineReducers({
     resetMap: resetMapReducer,
     geocode: getGeocodeReducer,
     importGeom: importGeomReducer,
-    form: reduxFormReducer,
     user: userReducer,
     routing: routerReducer,
     drawerOpen: drawerMenuReducer,

--- a/eventkit_cloud/ui/static/ui/app/reducers/rootReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/rootReducer.js
@@ -29,7 +29,6 @@ const rootReducer = combineReducers({
     providers: getProvidersReducer,
     stepperNextEnabled: stepperReducer,
     submitJob: submitJobReducer,
-    setExportPackageFlag: startExportPackageReducer,
     runsDeletion: DeleteRunsReducer,
     datacartDetails: getDatacartDetailsReducer,
     datacartDetailsReceived: setDatacartDetailsReducer,

--- a/eventkit_cloud/ui/static/ui/app/tests/BreadcrumbStepper.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/BreadcrumbStepper.spec.js
@@ -95,16 +95,6 @@ describe('BreadcrumbStepper component', () => {
         stateSpy.restore();
     });
 
-    it('handleNext should call setExportInfoDone', () => {
-        let props = getProps();
-        props.setExportInfoDone = new sinon.spy();
-        const wrapper = getWrapper(props);
-        wrapper.setState({stepIndex: 1});
-        expect(props.setExportInfoDone.called).toBe(false);
-        wrapper.instance().handleNext();
-        expect(props.setExportInfoDone.calledOnce).toBe(true); 
-    });
-
     it('incrementStepper should increment the stepIndex', () => {
         const props = getProps();
         const stateSpy = new sinon.spy(BreadcrumbStepper.prototype, 'setState');

--- a/eventkit_cloud/ui/static/ui/app/tests/BreadcrumbStepper.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/BreadcrumbStepper.spec.js
@@ -95,17 +95,6 @@ describe('BreadcrumbStepper component', () => {
         stateSpy.restore();
     });
 
-    it('incrementStepper should increment the stepIndex', () => {
-        const props = getProps();
-        const stateSpy = new sinon.spy(BreadcrumbStepper.prototype, 'setState');
-        const wrapper = getWrapper(props);
-        expect(stateSpy.called).toBe(false);
-        wrapper.instance().incrementStepper();
-        expect(stateSpy.calledOnce).toBe(true);
-        expect(stateSpy.calledWith({stepIndex: 1})).toBe(true);
-        stateSpy.restore();
-    });
-
     it('handlePrev should decrement the stepIndex only when index is > 0', () => {
         const props = getProps();
         const stateSpy = new sinon.spy(BreadcrumbStepper.prototype, 'setState');
@@ -147,9 +136,8 @@ describe('BreadcrumbStepper component', () => {
         content = wrapper.instance().getStepContent(1);
         expect(isEqual(content, <ExportInfo 
             providers={props.providers} 
-            incrementStepper={wrapper.instance().incrementStepper}
             handlePrev={wrapper.instance().handlePrev}/>)).toBe(true);
-        
+
         content = wrapper.instance().getStepContent(2);
         expect(isEqual(content, <ExportSummary/>)).toBe(true);
 

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
@@ -1,14 +1,29 @@
-import {ExportInfo} from '../../components/CreateDataPack/ExportInfo'
 import React from 'react'
-import {mount, shallow} from 'enzyme'
+import sinon from 'sinon';
+import {mount} from 'enzyme'
 import {fakeStore} from '../../__mocks__/fakeStore'
-import { Provider } from 'react-redux'
+import {Provider} from 'react-redux'
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import injectTapEventPlugin from 'react-tap-event-plugin';
+import {ExportInfo} from '../../components/CreateDataPack/ExportInfo'
 import CustomScrollbar from '../../components/CustomScrollbar';
+import ol from 'openlayers';
+import { RadioButton } from 'material-ui/RadioButton';
+import { List, ListItem} from 'material-ui/List';
+import {Card, CardActions, CardHeader, CardText} from 'material-ui/Card';
+import TextField from 'material-ui/TextField';
+import ActionCheckCircle from 'material-ui/svg-icons/action/check-circle';
+import UncheckedCircle from 'material-ui/svg-icons/toggle/radio-button-unchecked';
+import Paper from 'material-ui/Paper';
+import Checkbox from 'material-ui/Checkbox';
+import debounce from 'lodash/debounce';
+
 
 describe('ExportInfo component', () => {
+    const muiTheme = getMuiTheme();
+    injectTapEventPlugin();
     const getProps = () => {
         return {
-            providers: [],
             geojson: { 
                 "type": "FeatureCollection",
                 "features": [{ "type": "Feature",
@@ -26,52 +41,187 @@ describe('ExportInfo component', () => {
                 projectName: '',
                 makePublic: false,
             },
+            providers: [],
+            nextEnabled: true,
+            handlePrev: () => {},
             updateExportInfo: () => {},
             setNextDisabled: () => {},
             setNextEnabled: () => {},
-            setExportInfoNotDone: () => {},
         }
     }
+
+    const getWrapper = (props) => {
+        const store = fakeStore({});        
+        return mount(<ExportInfo {...props}/>, {
+            context: {muiTheme},
+            childContextTypes: {muiTheme: React.PropTypes.object}
+        });
+    }
+
     it('should render a form', () => {
-        const store = fakeStore({});
         const props = getProps();
-        const wrapper = mount(<Provider store={store}><ExportInfo {...props}/></Provider>);
+        const wrapper = getWrapper(props);
         expect(wrapper.find('.root')).toHaveLength(1);
+        expect(wrapper.find(CustomScrollbar)).toHaveLength(1);        
         expect(wrapper.find('.form')).toHaveLength(1);
         expect(wrapper.find('.paper')).toHaveLength(1);
-    })
-
-    it('should render a CustomScrollbar component', () => {
-        const store = fakeStore({});
-        const props = getProps();
-        const wrapper = mount(<Provider store={store}><ExportInfo {...props}/></Provider>);
-        expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
-    })
-
-    it('should render a General Information Div', () => {
-        const store = fakeStore({});
-        const props = getProps();
-        const wrapper = mount(<Provider store={store}><ExportInfo {...props}/></Provider>);
-        expect(wrapper.find('#mainHeading').text()).toEqual('Enter General Information');
-        // expect(wrapper.find('.fieldWrapper')).toHaveLength(2);
-        // expect(wrapper.find('.fieldWrapperLarge')).toHaveLength(1);
-        // expect(wrapper.find('#datapackName')).toHaveLength(1);
-        // expect(wrapper.find('#description')).toHaveLength(1);
-        // expect(wrapper.find('#projectName')).toHaveLength(1);
-        // expect(wrapper.find('#makePublic')).toHaveLength(1);
-    })
-
-    it('should render a Data Providers Div', () => {
-        const store = fakeStore({});
-        const props = getProps();
-        const wrapper = mount(<Provider store={store}><ExportInfo {...props}/></Provider>);
+        expect(wrapper.find('#mainHeading')).toHaveLength(1);
+        expect(wrapper.find(TextField)).toHaveLength(3);
+        expect(wrapper.find('#layersHeader')).toHaveLength(1);
         expect(wrapper.find('#layersHeader').text()).toEqual('Select Data Sources');
-        expect(wrapper.find('.subHeading')).toHaveLength(1);
-        expect(wrapper.find('.subHeading').text()).toEqual('You must choose at least one');
-        // expect(wrapper.find('.sectionBottom')).toHaveLength(1);
-        expect(wrapper.find('.list')).toHaveLength(1);
-        // expect(wrapper.find('.checkboxColor')).toHaveLength(5)
+        expect(wrapper.find('#layersSubheader').text()).toEqual('You must choose at least one');
+        expect(wrapper.find(List)).toHaveLength(1);
+        expect(wrapper.find(ListItem)).toHaveLength(0);
+        expect(wrapper.find('#projectionHeader')).toHaveLength(1);
+        expect(wrapper.find('#projectionHeader').text()).toEqual('Select Projection');
+        expect(wrapper.find('#projectionCheckbox').find(Checkbox)).toHaveLength(1);
+        expect(wrapper.find('#formatsHeader')).toHaveLength(1);
+        expect(wrapper.find('#formatsCheckbox').find(Checkbox)).toHaveLength(1);
+        expect(wrapper.find(Card)).toHaveLength(1);
+        expect(wrapper.find(CardHeader)).toHaveLength(1);
+        expect(wrapper.find(CardText)).toHaveLength(0);
+    });
 
-    })
+    it('card should expand and show a map', () => {
 
+    });
+
+    it('componentDidMount should setNextDisabled, setArea, create deboucers, and add eventlistener', () => {
+        const props = getProps();
+        props.setNextDisabled = new sinon.spy();
+        const mountSpy = new sinon.spy(ExportInfo.prototype, 'componentDidMount');
+        const areaSpy = new sinon.spy(ExportInfo.prototype, 'setArea');
+        const hasFieldsSpy = new sinon.spy(ExportInfo.prototype, 'hasRequiredFields');
+        const listenerSpy = new sinon.spy(window, 'addEventListener');
+        // const debounceSpy = new sinon.spy(debounce.prototype);
+        const wrapper = getWrapper(props);
+        expect(mountSpy.calledOnce).toBe(true);
+        expect(hasFieldsSpy.calledOnce).toBe(true);
+        expect(hasFieldsSpy.calledWith(props.exportInfo)).toBe(true);
+        expect(props.setNextDisabled.calledOnce).toBe(true);
+        expect(areaSpy.calledOnce).toBe(true);
+        // expect(debounceSpy.called).toBe(true);
+        expect(listenerSpy.called).toBe(true);
+        expect(listenerSpy.calledWith('resize', wrapper.instance().screenSizeUpdate)).toBe(true);
+        mountSpy.restore();
+        areaSpy.restore();
+        hasFieldsSpy.restore();
+        listenerSpy.restore();
+    });
+
+    it('componentDidUpdate should initializeOpenLayers if expanded', () => {
+        const props = getProps();
+        const initSpy = new sinon.spy();
+        const updateSpy = new sinon.spy(ExportInfo.prototype, 'componentDidUpdate');
+        const wrapper = getWrapper(props);
+        wrapper.instance()._initializeOpenLayers = initSpy;
+        expect(wrapper.state().expanded).toBe(false);
+        wrapper.setState({expanded: true});
+        expect(updateSpy.calledOnce).toBe(true);
+        expect(wrapper.state().expanded).toBe(true);
+        expect(initSpy.calledOnce).toBe(true);
+        updateSpy.restore();
+    });
+
+    it('componentWillUnmount should remove the event listener', () => {
+        const props = getProps();
+        const unmountSpy = new sinon.spy(ExportInfo.prototype, 'componentWillUnmount');
+        const listenerSpy = new sinon.spy(window, 'removeEventListener');1
+        const wrapper = getWrapper(props);
+        const func = wrapper.instance().screenSizeUpdate;
+        wrapper.unmount();
+        expect(unmountSpy.calledOnce).toBe(true);
+        expect(listenerSpy.called).toBe(true);
+        expect(listenerSpy.calledWith('resize', func)).toBe(true);
+    });
+
+    it('componentWillReceiveProps should setNextEnabled', () => {
+        const props = getProps();
+        props.setNextEnabled = new sinon.spy();
+        const wrapper = getWrapper(props);
+        expect(props.setNextEnabled.called).toBe(false);
+        const nextProps = getProps();
+        nextProps.exportInfo.exportName = 'name';
+        nextProps.exportInfo.datapackDescription = 'description';
+        nextProps.exportInfo.projectName = 'project';
+        nextProps.exportInfo.providers = [{}];
+        nextProps.nextEnabled = false;
+        wrapper.setProps(nextProps);
+        expect(props.setNextEnabled.calledOnce).toBe(true);
+    });
+
+    it('componentWillReceiveProps should setNextDisabled', () => {
+        const props = getProps();
+        props.setNextDisabled = new sinon.spy();
+        const wrapper = getWrapper(props);
+        expect(props.setNextDisabled.calledOnce).toBe(true);
+        const nextProps = getProps();
+        nextProps.nextEnabled = true;
+        wrapper.setProps(nextProps);
+        expect(props.setNextDisabled.calledTwice).toBe(true);
+    });
+
+    it('screenSizeUpdate should force an update', () => {
+        const props = getProps();
+        const forceSpy = new sinon.spy(ExportInfo.prototype, 'forceUpdate');
+        const wrapper = getWrapper(props);
+        expect(forceSpy.called).toBe(false);
+        wrapper.instance().screenSizeUpdate();
+        expect(forceSpy.calledOnce).toBe(true);
+        forceSpy.restore();
+    });
+
+    it('onNameChange should call persist and nameHandler', () => {
+        const props = getProps();
+        const event = {persist: new sinon.spy()}
+        const wrapper = getWrapper(props);
+        wrapper.instance().nameHandler = new sinon.spy();
+        wrapper.instance().onNameChange(event);
+        expect(event.persist.calledOnce).toBe(true);
+        expect(wrapper.instance().nameHandler.calledOnce).toBe(true);
+        expect(wrapper.instance().nameHandler.calledWith(event)).toBe(true);
+    });
+
+    it('onDescriptionChange should call persist and nameHandler', () => {
+        const props = getProps();
+        const event = {persist: new sinon.spy()}
+        const wrapper = getWrapper(props);
+        wrapper.instance().descriptionHandler = new sinon.spy();
+        wrapper.instance().onDescriptionChange(event);
+        expect(event.persist.calledOnce).toBe(true);
+        expect(wrapper.instance().descriptionHandler.calledOnce).toBe(true);
+        expect(wrapper.instance().descriptionHandler.calledWith(event)).toBe(true);
+    });
+
+    it('onProjectChange should call persist and nameHandler', () => {
+        const props = getProps();
+        const event = {persist: new sinon.spy()}
+        const wrapper = getWrapper(props);
+        wrapper.instance().projectHandler = new sinon.spy();
+        wrapper.instance().onProjectChange(event);
+        expect(event.persist.calledOnce).toBe(true);
+        expect(wrapper.instance().projectHandler.calledOnce).toBe(true);
+        expect(wrapper.instance().projectHandler.calledWith(event)).toBe(true);
+    });
+
+    it('onChangeCheck should add a provider', () => {
+        const appProviders = [{name: 'one'}, {name: 'two'}];
+        const exportProviders = [{name: 'one'}];
+        const event = {target: {name: 'two', checked: true}};
+        const props = getProps();
+        props.updateExportInfo = new sinon.spy();
+        props.exportInfo.providers = exportProviders;
+        props.providers = appProviders;
+        const wrapper = getWrapper(props);
+        wrapper.instance().onChangeCheck(event);
+        expect(props.updateExportInfo.called).toBe(true);
+        // expect(props.updateExportInfo.calledWith({
+        //     ...props.exportInfo,
+        //     providers: [{name: 'one', name: 'two'}]
+        // })).toBe(true);
+    });
+
+    it('onChangeCheck should remove a provider', () => {
+
+    });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
@@ -6,15 +6,11 @@ import injectTapEventPlugin from 'react-tap-event-plugin';
 import {ExportInfo} from '../../components/CreateDataPack/ExportInfo'
 import CustomScrollbar from '../../components/CustomScrollbar';
 import ol from 'openlayers';
-import { RadioButton } from 'material-ui/RadioButton';
 import { List, ListItem} from 'material-ui/List';
 import {Card, CardActions, CardHeader, CardText} from 'material-ui/Card';
 import TextField from 'material-ui/TextField';
-import ActionCheckCircle from 'material-ui/svg-icons/action/check-circle';
-import UncheckedCircle from 'material-ui/svg-icons/toggle/radio-button-unchecked';
 import Paper from 'material-ui/Paper';
 import Checkbox from 'material-ui/Checkbox';
-import debounce from 'lodash/debounce';
 
 // this polyfills requestAnimationFrame in the test browser, required for ol3
 import raf from 'raf';
@@ -102,6 +98,9 @@ describe('ExportInfo component', () => {
         expect(areaSpy.calledOnce).toBe(true);
         expect(listenerSpy.called).toBe(true);
         expect(listenerSpy.calledWith('resize', wrapper.instance().screenSizeUpdate)).toBe(true);
+        expect(wrapper.instance().nameHandler).not.toBe(undefined);
+        expect(wrapper.instance().descriptionHandler).not.toBe(undefined);
+        expect(wrapper.instance().projectHandler).not.toBe(undefined);
         mountSpy.restore();
         areaSpy.restore();
         hasFieldsSpy.restore();
@@ -125,7 +124,7 @@ describe('ExportInfo component', () => {
     it('componentWillUnmount should remove the event listener', () => {
         const props = getProps();
         const unmountSpy = new sinon.spy(ExportInfo.prototype, 'componentWillUnmount');
-        const listenerSpy = new sinon.spy(window, 'removeEventListener');1
+        const listenerSpy = new sinon.spy(window, 'removeEventListener');
         const wrapper = getWrapper(props);
         const func = wrapper.instance().screenSizeUpdate;
         wrapper.unmount();

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
@@ -20,7 +20,6 @@ describe('ExportInfo component', () => {
                         ]
                     },}]
             },
-            setExportPackageFlag: false,
             exportInfo: {
                 exportName: '',
                 datapackDescription: '',

--- a/eventkit_cloud/ui/static/ui/app/tests/actions/exportsActions.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/actions/exportsActions.spec.js
@@ -106,13 +106,6 @@ describe('export actions', () => {
         });
     });
 
-    it('exportInfoDone should return EXPORT_INFO_DONE and setExportPackageFlag to true', () => {
-        expect(actions.exportInfoDone()).toEqual({
-            type: 'EXPORT_INFO_DONE',
-            setExportPackageFlag: true
-        });
-    });
-
     it('stepperNextDisabled should return MAKE_STEPPER_INACTIVE and false', () => {
         expect(actions.stepperNextDisabled()).toEqual({
             type: 'MAKE_STEPPER_INACTIVE',

--- a/eventkit_cloud/ui/static/ui/app/tests/actions/exportsActions.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/actions/exportsActions.spec.js
@@ -56,15 +56,25 @@ describe('export actions', () => {
     });
 
     it('updateExportInfo should return passed in json', () => {
-        expect(actions.updateExportInfo('exportName', 'datapackDescription', 'projectName', true, ['provider1'], 'area_str', ['layer1'])).toEqual({
+        expect(actions.updateExportInfo({
+            exportName: 'exportName', 
+            datapackDescription: 'datapackDescription', 
+            projectName: 'projectName', 
+            makePublic: true, 
+            providers: ['provider1'], 
+            area_str: 'area_str', 
+            layers: ['layer1']
+        })).toEqual({
             type: 'UPDATE_EXPORT_INFO',
-            exportName: 'exportName',
-            datapackDescription: 'datapackDescription',
-            projectName: 'projectName',
-            makePublic: true,
-            providers: ['provider1'],
-            area_str: 'area_str',
-            layers: ['layer1'],
+            exportInfo: {
+                exportName: 'exportName', 
+                datapackDescription: 'datapackDescription', 
+                projectName: 'projectName', 
+                makePublic: true, 
+                providers: ['provider1'], 
+                area_str: 'area_str', 
+                layers: ['layer1']
+            }
         });
     });
 

--- a/eventkit_cloud/ui/static/ui/app/tests/reducers/exportsReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/reducers/exportsReducer.spec.js
@@ -35,7 +35,7 @@ describe('exportInfo reducer', () => {
             makePublic: false,
             providers: [],
             area_str: '',
-            layers: ''
+            layers: 'Geopackage'
         });
     });
 
@@ -52,13 +52,15 @@ describe('exportInfo reducer', () => {
             },
             {
                 type: 'UPDATE_EXPORT_INFO',
-                exportName: 'name',
-                datapackDescription: 'description',
-                projectName: 'project',
-                makePublic: true,
-                providers: ['provider'],
-                area_str: 'string',
-                layers: 'layer'
+                exportInfo: {
+                    exportName: 'name',
+                    datapackDescription: 'description',
+                    projectName: 'project',
+                    makePublic: true,
+                    providers: ['provider'],
+                    area_str: 'string',
+                    layers: 'layer'
+                }
             }
         )).toEqual({
             exportName: 'name',

--- a/package.json
+++ b/package.json
@@ -45,8 +45,6 @@
     "redux": "~3.6.0",
     "redux-auth-wrapper": "~1.0.0",
     "redux-debounced": "~0.4.0",
-    "redux-form": "~6.4.3",
-    "redux-form-material-ui": "~4.2.0",
     "redux-mock-store": "~1.2.2",
     "redux-logger": "~2.7.4",
     "redux-thunk": "~2.1.0",


### PR DESCRIPTION
This PR refactors how ExportInfo.js stores the form data. Instead of maintaining a local and redux state, we now only use redux. This allows the user to go back to the Draw step without losing any form data they have filled out. No appearance changes included