### PR TITLE
Fix bug where going back to edit selected aoi would revert the ui.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/actions/exportsActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/exportsActions.js
@@ -9,13 +9,14 @@ export function createExportRequest(exportData) {
     }
 }
 
-export function updateAoiInfo(geojson, geomType, title, description,) {
+export function updateAoiInfo(geojson, geomType, title, description, selectionType) {
     return {
         type: types.UPDATE_AOI_INFO,
         geojson: geojson,
         geomType,
         title,
         description,
+        selectionType,
     }
 }
 export function updateExportInfo(exportInfo) {

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/AoiInfobar.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/AoiInfobar.js
@@ -28,6 +28,10 @@ export class AoiInfobar extends Component {
         }
     }
 
+    componentDidMount() {
+        this.handleAoiInfo(this.props.aoiInfo);
+    }
+
     componentWillReceiveProps(nextProps) {
         if(!isEqual(nextProps.aoiInfo.geojson, this.props.aoiInfo.geojson)) {
             this.handleAoiInfo(nextProps.aoiInfo);

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -64,6 +64,7 @@ export class ExportAOI extends Component {
             //zoomToGeometry(bbox);
             this._map.getView().fit(this._drawLayer.getSource().getExtent())
             this.props.setNextEnabled();
+            this.setButtonSelected(this.props.aoiInfo.selectionType);
         }
     }
 
@@ -159,7 +160,7 @@ export class ExportAOI extends Component {
         description = description + (result.province ? ', ' + result.province : '');
         description = description + (result.region ? ', ' + result.region : '');
 
-        this.props.updateAoiInfo(geojson, result.geometry.type, result.name, description);
+        this.props.updateAoiInfo(geojson, result.geometry.type, result.name, description, 'search');
         zoomToGeometry(feature.getGeometry(), this._map);
         if(feature.getGeometry().getType()=='Polygon' || feature.getGeometry().getType()=='MultiPolygon') {
             this.props.setNextEnabled();
@@ -176,7 +177,7 @@ export class ExportAOI extends Component {
         )
         const geojson = createGeoJSON(geom);
         zoomToGeometry(geom, this._map);
-        this.props.updateAoiInfo(geojson, geom.getType(), 'Custom Area', 'Import');
+        this.props.updateAoiInfo(geojson, geom.getType(), 'Custom Area', 'Import', 'import');
         this.props.setNextEnabled();
 
     }
@@ -194,7 +195,7 @@ export class ExportAOI extends Component {
         });
         const bbox = serialize(extent)
         this._drawLayer.getSource().addFeature(bboxFeature);
-        this.props.updateAoiInfo(geojson, 'Polygon', 'Custom Polygon', 'Map View');
+        this.props.updateAoiInfo(geojson, 'Polygon', 'Custom Polygon', 'Map View', 'mapView');
         this.props.setNextEnabled();
     }
 
@@ -236,7 +237,7 @@ export class ExportAOI extends Component {
                 this._drawLayer.getSource().addFeature(drawFeature);
 
                 if(isGeoJSONValid(geojson)) {
-                    this.props.updateAoiInfo(geojson, 'Polygon', 'Custom Polygon', 'Draw');
+                    this.props.updateAoiInfo(geojson, 'Polygon', 'Custom Polygon', 'Draw', 'free');
                     this.props.setNextEnabled();
                 }
                 else {
@@ -245,7 +246,7 @@ export class ExportAOI extends Component {
             }
             else if (this.state.mode == MODE_DRAW_BBOX) {
                 const bbox = serialize(geometry.getExtent());
-                this.props.updateAoiInfo(geojson, 'Polygon', 'Custom Polygon', 'Box');
+                this.props.updateAoiInfo(geojson, 'Polygon', 'Custom Polygon', 'Box', 'box');
                 this.props.setNextEnabled();
             }
             // exit drawing mode
@@ -413,8 +414,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        updateAoiInfo: (geojson, geomType, title, description) => {
-            dispatch(updateAoiInfo(geojson, geomType, title, description));
+        updateAoiInfo: (geojson, geomType, title, description, selectionType) => {
+            dispatch(updateAoiInfo(geojson, geomType, title, description, selectionType));
         },
         clearAoiInfo: () => {
             dispatch(clearAoiInfo());

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
@@ -224,7 +224,7 @@ function mapDispatchToProps(dispatch) {
             dispatch(clearReRunInfo())
         },
         cloneExport: (cartDetails, providerArray) => {
-            dispatch(updateAoiInfo({type: "FeatureCollection", features: [cartDetails.job.extent]}, 'Polygon', 'Custom Polygon', 'Box'));
+            dispatch(updateAoiInfo({type: "FeatureCollection", features: [cartDetails.job.extent]}, 'Polygon', 'Custom Polygon', 'Box', 'box'));
             dispatch(updateExportInfo({
                 exportName: cartDetails.job.name, 
                 datapackDescription: cartDetails.job.description, 

--- a/eventkit_cloud/ui/static/ui/app/reducers/exportsReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/exportsReducer.js
@@ -32,6 +32,7 @@ export function exportAoiInfoReducer(state = initialState.aoiInfo, action) {
                 geomType: action.geomType,
                 title: action.title,
                 description: action.description,
+                selectionType: action.selectionType,
             };
         case types.CLEAR_AOI_INFO:
             return {

--- a/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
@@ -8,6 +8,7 @@ export default {
         geomType: null,
         title: null,
         description: null,
+        selectionType: null,
     },
     zoomToSelection: {
         click: false

--- a/eventkit_cloud/ui/static/ui/app/tests/reducers/exportsReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/reducers/exportsReducer.spec.js
@@ -2,7 +2,7 @@ import * as reducers from '../../reducers/exportsReducer'
 
 describe('exportAoiInfo reducer', () => {
     it('should return initial state', () => {
-        expect(reducers.exportAoiInfoReducer(undefined, {})).toEqual({geojson: {}, geomType: null, title: null, description:null})
+        expect(reducers.exportAoiInfoReducer(undefined, {})).toEqual({geojson: {}, geomType: null, title: null, description:null, selectionType: null})
     });
 
     it('should handle UPDATE_AOI_INFO', () => {
@@ -21,8 +21,8 @@ describe('exportAoiInfo reducer', () => {
                     }
         expect(reducers.exportAoiInfoReducer(
             {},
-            {type: 'UPDATE_AOI_INFO', geojson: geojson, geomType: 'Polygon', title: 'title', description: 'description'}
-        )).toEqual({geojson: geojson, geomType: 'Polygon', title: 'title', description: 'description'});
+            {type: 'UPDATE_AOI_INFO', geojson: geojson, geomType: 'Polygon', title: 'title', description: 'description', selectionType: 'type'}
+        )).toEqual({geojson: geojson, geomType: 'Polygon', title: 'title', description: 'description', selectionType: 'type'});
     });
 });
 


### PR DESCRIPTION
Steps to repeat:
- Click "Create DataPack"
- Set AOI
- Click "Next" button to proceed to step 2
- Click "Back" button to return to step 1 (or click edit on Selected AOI widget)
- Notice incorrect UI state

Before:
![selection_021](https://user-images.githubusercontent.com/3220897/30298988-7adaa640-9702-11e7-90fa-f92180857ab0.png)

After:
![selection_022](https://user-images.githubusercontent.com/3220897/30298991-7fceefbc-9702-11e7-991b-59686c46f891.png)
