### PR TITLE
Add CustomTextField component for displaying remaining characters.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -17,6 +17,7 @@ import {updateExportInfo, stepperNextEnabled, stepperNextDisabled, exportInfoNot
 import debounce from 'lodash/debounce';
 import Info from 'material-ui/svg-icons/action/info';
 import BaseDialog from '../BaseDialog';
+import CustomTextField from "../CustomTextField";
 
 
 export class ExportInfo extends React.Component {
@@ -259,7 +260,7 @@ export class ExportInfo extends React.Component {
                     <form className={styles.form} onSubmit={this.onSubmit} style={style.window}>
                         <Paper className={styles.paper} zDepth={2} rounded>
                             <div id='mainHeading' className={styles.heading}>Enter General Information</div>
-                            <TextField
+                            <CustomTextField
                                 id='nameField' 
                                 name="exportName"
                                 ref="exportName"
@@ -273,7 +274,7 @@ export class ExportInfo extends React.Component {
                                 hintStyle={{fontSize: '16px', paddingLeft: '5px'}}
                                 maxLength={100}
                             />
-                            <TextField
+                            <CustomTextField
                                 id='descriptionField'
                                 underlineStyle={style.underlineStyle}
                                 underlineFocusStyle={style.underlineStyle}
@@ -288,7 +289,7 @@ export class ExportInfo extends React.Component {
                                 hintStyle={{fontSize: '16px', paddingLeft: '5px'}}
                                 maxLength={1000}
                             />
-                            <TextField
+                            <CustomTextField
                                 id='projectField'
                                 underlineStyle={style.underlineStyle}
                                 underlineFocusStyle={style.underlineStyle}

--- a/eventkit_cloud/ui/static/ui/app/components/CustomTextField.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CustomTextField.js
@@ -1,0 +1,94 @@
+import React, {Component} from 'react';
+import {TextField} from 'material-ui';
+import _ from 'lodash';
+import * as ReactDOM from 'react-dom';
+
+export class CustomTextField extends Component {
+    constructor(props) {
+        super(props);
+
+        this.textFieldProps = _.clone(this.props);
+        delete this.textFieldProps.showRemaining;
+        delete this.textFieldProps.onChange;
+
+        this.state = {
+            charsRemaining: this.props.maxLength,
+            focused: false,
+        }
+
+        this.styles = {
+            charsRemaining: {
+                position: 'absolute',
+                bottom: '4px',
+                right: '16px',
+                transform: 'translateY(-50%)',
+                fontWeight: 'bold'
+            }
+        }
+    }
+
+    onChange = (e) => {
+        if (this.props.onChange) {
+            this.props.onChange(e);
+        }
+
+        this.setState({charsRemaining: this.props.maxLength - e.target.value.length});
+    }
+
+    onFocus = (e) => {
+        if (this.props.onFocus) {
+            this.props.onFocus(e);
+        }
+
+        this.setState({focused: true});
+    }
+
+    onBlur = (e) => {
+        if (this.props.onBlur) {
+            this.props.onBlur(e);
+        }
+
+        this.setState({focused: false});
+    }
+
+    render() {
+        const charsRemainingColor = (this.state.charsRemaining > 10) ? '#B4B7B8' : '#CE4427';
+
+        return (
+            <div style={{position: 'relative'}}>
+                <TextField
+                    id={_.uniqueId()}
+                    ref={(textField) => {
+                        if (!textField) {
+                            return;
+                        }
+
+                        if (this.props.maxLength && this.props.showRemaining) {
+                            ReactDOM.findDOMNode(textField).style.paddingRight = '55px';
+                        }
+                    }}
+                    onChange={this.onChange}
+                    onFocus={this.onFocus}
+                    onBlur={this.onBlur}
+                    {...this.textFieldProps}
+                />
+                {(this.props.maxLength && this.props.showRemaining && this.state.focused) ?
+                <div
+                    style={{...this.styles.charsRemaining, color: charsRemainingColor}}>
+                    {this.state.charsRemaining}
+                </div>
+                : null}
+            </div>
+        )
+    }
+}
+
+CustomTextField.propTypes = {
+    showRemaining: React.PropTypes.bool,
+};
+
+CustomTextField.defaultProps = {
+    showRemaining: true
+}
+
+export default CustomTextField

--- a/eventkit_cloud/ui/static/ui/app/tests/CustomTextField.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CustomTextField.spec.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import CustomTextField from '../components/CustomTextField';
+import {TextField} from 'material-ui';
+
+describe('CustomTextField component', () => {
+    const muiTheme = getMuiTheme();
+
+    it('should render a material-ui TextField component', () => {
+        const wrapper = mount(<CustomTextField/>, {
+            context: {muiTheme},
+            childContextTypes: {muiTheme: React.PropTypes.object}
+        });
+        expect(wrapper.find(TextField)).toHaveLength(1);
+    });
+
+    it('should show remaining characters when maxLength is present and input is focused', () => {
+        const wrapper = mount(<CustomTextField maxLength={100}/>, {
+            context: {muiTheme},
+            childContextTypes: {muiTheme: React.PropTypes.object}
+        });
+        const input = wrapper.find('input');
+        const charsRemaining = wrapper.find(TextField).parent().last('div');
+
+        input.simulate('focus');
+        expect(charsRemaining.text()).toEqual('100');
+        input.simulate('change', {target: {value: 'abc'}});
+        expect(charsRemaining.text()).toEqual('97');
+        input.simulate('blur');
+        expect(charsRemaining.text()).toEqual('');
+    });
+
+    it('should not show remaining characters when showRemaining is false', () => {
+        const wrapper = mount(<CustomTextField maxLength={100} showRemaining={false}/>, {
+            context: {muiTheme},
+            childContextTypes: {muiTheme: React.PropTypes.object}
+        });
+        const input = wrapper.find('input');
+        const charsRemaining = wrapper.find(TextField).parent().last('div');
+
+        input.simulate('focus');
+        expect(charsRemaining.text()).toEqual('');
+    });
+});


### PR DESCRIPTION
The number of remaining characters should be displayed on the right of the text field while it's focused, and disappear when it loses focus. When the count is 10 or lower, it should turn red. The only text fields currently using CustomTextField are the three in ExportInfo, since that seems to be where it matters the most for the user to know their character limit.

![selection_029](https://user-images.githubusercontent.com/3220897/30457803-b8f24322-995d-11e7-9b01-a291e9cb82d4.png)
