### PR TITLE
Default description textfield to a single row.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -282,7 +282,6 @@ export class ExportInfo extends React.Component {
                                 defaultValue={this.props.exportInfo.datapackDescription}
                                 hintText="Description"
                                 multiLine={true}
-                                rows={2}
                                 style={{backgroundColor: 'whitesmoke', width: '100%', marginTop: '15px'}}
                                 textareaStyle={{fontSize: '16px', paddingLeft: '5px'}}
                                 hintStyle={{fontSize: '16px', paddingLeft: '5px'}}


### PR DESCRIPTION
This change wasn't discussed, but seemed like an obvious one since the description text field looked a bit wonky starting at two rows. The way the label was sitting on the bottom made it look like some sort of padding glitch. It works just as well starting as a single row and looks more polished I think. With the addition of remaining characters being displayed, it should be obvious that you can enter more text into that field than the others.

Before:
![selection_033](https://user-images.githubusercontent.com/3220897/30458243-893737c6-995f-11e7-98a7-1b5e65eb9420.png)

After:
![selection_034](https://user-images.githubusercontent.com/3220897/30458246-8d0c7d20-995f-11e7-9b02-599dc44db957.png)
