### PR TITLE
Redirect from create and status pages if user hasn't agreed to licenses.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/index.js
+++ b/eventkit_cloud/ui/static/ui/app/index.js
@@ -80,12 +80,12 @@ render(
                 <Route path="/exports" component={UserIsAuthenticated(UserHasAgreed(DataPackPage))}>
                     <Route path="/export/:uid" component={UserIsAuthenticated(UserHasAgreed(Export))}/>
                 </Route>
-                <Route path="/create" component={UserIsAuthenticated(CreateExport)}>
-                    <Route path="/exportAOI" component={UserIsAuthenticated(ExportAOI)}/>
-                    <Route path="/exportInfo" component={UserIsAuthenticated(ExportInfo)}/>
-                    <Route path="/exportSummary" component={UserIsAuthenticated(ExportSummary)}/>
+                <Route path="/create" component={UserIsAuthenticated(UserHasAgreed(CreateExport))}>
+                    <Route path="/exportAOI" component={UserIsAuthenticated(UserHasAgreed(ExportAOI))}/>
+                    <Route path="/exportInfo" component={UserIsAuthenticated(UserHasAgreed(ExportInfo))}/>
+                    <Route path="/exportSummary" component={UserIsAuthenticated(UserHasAgreed(ExportSummary))}/>
                 </Route>
-                <Route path="/status/:jobuid" component={UserIsAuthenticated(StatusDownload)}/>
+                <Route path="/status/:jobuid" component={UserIsAuthenticated(UserHasAgreed(StatusDownload))}/>
                 <Route path="/about" component={UserIsAuthenticated(About)}/>
                 <Route path="/account" component={UserIsAuthenticated(Account)}/>
             </Route>


### PR DESCRIPTION
This fixes an issue where it was possible to navigate to the create and status pages without first agreeing to the licenses. Now, the only pages that should be accessible without agreeing are Login, About, and Account.