### PR TITLE
Fix upside down chevrons on providers in Status & Download page.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
@@ -367,7 +367,7 @@ export class ProviderRow extends React.Component {
                         </TableHeaderColumn>
                         <TableHeaderColumn style={{paddingRight: '0px', paddingLeft: '0px', width: toggleCellWidth, textAlign: 'left'}}>
                             <IconButton disableTouchRipple={true} onTouchTap={this.handleToggle} iconStyle={{fill: '4598bf'}}>
-                                {this.state.openTable ? <ArrowDown/> : <ArrowUp/>}
+                                {this.state.openTable ? <ArrowUp/> : <ArrowDown/>}
                             </IconButton>
                         </TableHeaderColumn>
                     </TableRow>

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
@@ -10,7 +10,7 @@ import {Table, TableBody, TableHeader, TableHeaderColumn, TableRow, TableRowColu
     from 'material-ui/Table';
 import Checkbox from 'material-ui/Checkbox';
 import NavigationMoreVert from 'material-ui/svg-icons/navigation/more-vert';
-import ArrowUp from 'material-ui/svg-icons/hardware/keyboard-arrow-up';
+import ArrowDown from 'material-ui/svg-icons/hardware/keyboard-arrow-down';
 import Warning from 'material-ui/svg-icons/alert/warning';
 import Check from 'material-ui/svg-icons/navigation/check';
 import CloudDownload from 'material-ui/svg-icons/file/cloud-download';
@@ -91,11 +91,11 @@ describe('ProviderRow component', () => {
         expect(wrapper.find(TableHeader)).toHaveLength(1);
         expect(wrapper.find(TableRow)).toHaveLength(1);
         expect(wrapper.find(TableHeaderColumn)).toHaveLength(5);
-        expect(wrapper.find(ArrowUp)).toHaveLength(1);
+        expect(wrapper.find(ArrowDown)).toHaveLength(1);
         //expect(wrapper.find(Checkbox)).toHaveLength(1);
         expect(wrapper.find(IconMenu)).toHaveLength(1);
         expect(wrapper.find(IconButton)).toHaveLength(2);
-        expect(wrapper.find(IconButton).find(ArrowUp)).toHaveLength(1);
+        expect(wrapper.find(IconButton).find(ArrowDown)).toHaveLength(1);
         expect(wrapper.find(MenuItem)).toHaveLength(0);
         expect(wrapper.find(BaseDialog)).toHaveLength(1);
     });


### PR DESCRIPTION
These should now be consistent with the rest of the app.

Before:
![selection_043](https://user-images.githubusercontent.com/3220897/30569392-81d8e0be-9c8f-11e7-91a8-cb7b0036747e.png)

After:
![selection_044](https://user-images.githubusercontent.com/3220897/30569404-8685639e-9c8f-11e7-94e9-0521beac21c6.png)
