### PR TITLE
Flip backwards chevrons for showing/hiding map overview.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -197,6 +197,8 @@ export class MapView extends Component {
                     className: ['ol-overviewmap', css['ol-custom-overviewmap']].join(' '),
                     collapsible: true,
                     collapsed: window.innerWidth < 768 ? true: false,
+                    collapseLabel: '\u00BB',
+                    label: '\u00AB',
                 }),
             ],
             interactions: ol.interaction.defaults({


### PR DESCRIPTION
Before:
![selection_059](https://user-images.githubusercontent.com/3220897/31066705-b97923e8-a703-11e7-911c-a913f67d8514.png)

After:
![selection_058](https://user-images.githubusercontent.com/3220897/31066707-bcafe894-a703-11e7-8eeb-d202237398bf.png)
