### PR TITLE
Keep show/hide filters button from shifting adjacent buttons on click.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackFilterButton.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackFilterButton.js
@@ -16,7 +16,7 @@ export class DataPackFilterButton extends React.Component {
                 height: '30px',
                 lineHeight: '15px',
                 minWidth: 'none',
-                maxWidth: window.innerWidth > 575 ? 'none': '40px'
+                width: window.innerWidth > 575 ? '90px' : '40px'
             },
             label: {
                 color: '#4498c0', 

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackFilterButton.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackFilterButton.spec.js
@@ -51,13 +51,13 @@ describe('DataPackFilterButton component', () => {
             context: {muiTheme},
             childContextTypes: {muiTheme: React.PropTypes.object}
         });
-        expect(wrapper.find(FlatButton).props().style.maxWidth).toEqual('none');
+        expect(wrapper.find(FlatButton).props().style.width).toEqual('90px');
         expect(wrapper.find(FlatButton).props().labelStyle.fontSize).toEqual('12px');
 
         window.resizeTo(400, 500);
         expect(window.innerWidth).toBe(400);
         wrapper.update();
-        expect(wrapper.find(FlatButton).props().style.maxWidth).toEqual('40px');
+        expect(wrapper.find(FlatButton).props().style.width).toEqual('40px');
         expect(wrapper.find(FlatButton).props().labelStyle.fontSize).toEqual('10px');
     });
 });


### PR DESCRIPTION
This fixes a minor issue where the view mode buttons would get shifted back and forth when showing/hiding filters. They should remain stationary now.

![selection_060](https://user-images.githubusercontent.com/3220897/31067395-886d0680-a707-11e7-9ced-a4f098a7c2e5.png)
