### PR TITLE
Small webpack changes

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CustomTextField.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CustomTextField.js
@@ -1,13 +1,14 @@
 import React, {Component} from 'react';
 import {TextField} from 'material-ui';
-import _ from 'lodash';
+import clone from 'lodash/clone';
+import uniqueId from 'lodash/uniqueId';
 import * as ReactDOM from 'react-dom';
 
 export class CustomTextField extends Component {
     constructor(props) {
         super(props);
 
-        this.textFieldProps = _.clone(this.props);
+        this.textFieldProps = clone(this.props);
         delete this.textFieldProps.showRemaining;
         delete this.textFieldProps.onChange;
 
@@ -58,7 +59,7 @@ export class CustomTextField extends Component {
             <div style={{position: 'relative'}}>
                 <TextField
                     className={'qa-CustomTextField-TextField'}
-                    id={_.uniqueId()}
+                    id={uniqueId()}
                     ref={(textField) => {
                         if (!textField) {
                             return;

--- a/eventkit_cloud/ui/static/ui/app/components/auth/Loading.js
+++ b/eventkit_cloud/ui/static/ui/app/components/auth/Loading.js
@@ -3,7 +3,7 @@ import CircularProgress from 'material-ui/CircularProgress';
 
 export default function Loading() {
   const constainerStyle = {
-    backgroundImage: 'url("../../images/ek_topo_pattern.png")', 
+    backgroundImage: 'url('+require('../../../images/ek_topo_pattern.png')+')', 
     height: window.innerHeight - 95, 
     width: window.innerWidth, 
     display: 'inline-flex'

--- a/eventkit_cloud/ui/static/ui/app/store/configureStore.js
+++ b/eventkit_cloud/ui/static/ui/app/store/configureStore.js
@@ -6,26 +6,30 @@ import { browserHistory } from 'react-router'
 import { routerMiddleware } from 'react-router-redux'
 import createDebounce from 'redux-debounced';
 
-const logger = createLogger();
 const bouncer = createDebounce();
-const baseHistory = browserHistory
-const routingMiddleware = routerMiddleware(baseHistory)
-
+const baseHistory = browserHistory;
+const routingMiddleware = routerMiddleware(baseHistory);
 
 const crashReporter = store => next => action => {
   try {
-    return next(action)
+    return next(action);
   } catch (err) {
-    console.error('Caught an exception!', err)
-    throw err
+    console.error('Caught an exception!', err);
+    throw err;
   }
 }
 
+let middleware = [bouncer, thunkMiddleware, crashReporter, routingMiddleware];
+
+if (process.env.NODE_ENV !== 'production') {
+  const logger = createLogger();
+  middleware = [...middleware, logger];
+}
 
 export default () => {
     return createStore(
         rootReducer,
-        applyMiddleware(bouncer, thunkMiddleware, logger, crashReporter, routingMiddleware)
+        applyMiddleware(...middleware)
    );
 }
 

--- a/eventkit_cloud/ui/static/ui/index.html
+++ b/eventkit_cloud/ui/static/ui/index.html
@@ -56,7 +56,7 @@
   <body>
 
     <div id='root'></div>
-    <script src="build/vendor.bundle.js"></script>
+    <script src="build/node-modules.js"></script>
     <script src="build/bundle.js"></script>
 
   </body>

--- a/eventkit_cloud/ui/templates/ui/index.html
+++ b/eventkit_cloud/ui/templates/ui/index.html
@@ -52,7 +52,7 @@
   <body>
 
     <div id='root'></div>
-    <script src="{% static 'ui/build/vendor.bundle.js' %}"></script>
+    <script src="{% static 'ui/build/node-modules.js' %}"></script>
     <script src="{% static 'ui/build/bundle.js' %}"></script>
 
   </body>

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "react-hot-loader": "3.0.0-beta.6",
     "redux-mock-store": "~1.2.1",
     "sinon" : "~1.17.7",
-    "write-file-webpack-plugin": "~4.0.2"
+    "write-file-webpack-plugin": "~4.0.2",
+    "webpack-bundle-analyzer":"~2.9.0"
   },
   "babel": {
     "plugins": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ var webpack = require('webpack');
 var path = require('path');
 var WriteFilePlugin = require('write-file-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 var BASE_DIR = path.resolve('/var', 'lib', 'eventkit', 'eventkit_cloud', 'ui', 'static', 'ui')
 var BUILD_DIR = path.resolve(BASE_DIR, 'build');
@@ -12,7 +13,18 @@ var devtool = 'source-map';
 var plugins = [
     new WriteFilePlugin(),
     new ExtractTextPlugin('styles.css'),
-    new webpack.optimize.CommonsChunkPlugin({name:'vendor', filename: 'vendor.bundle.js', minChunks: 'Infinity'}),
+    new webpack.optimize.CommonsChunkPlugin({
+        name:'node-modules', 
+        filename: 'node-modules.js', 
+        minChunks(module, count) {
+            var context = module.context;
+            return context && context.indexOf('node_modules') >= 0;
+        }
+    }),
+    new BundleAnalyzerPlugin({
+        analyzerMode: 'static',
+        reportFilename: 'report.html'
+    })
 ];
 var app = [APP_DIR + '/index.js'];
 
@@ -20,7 +32,6 @@ var config = {
     devtool: devtool,
     entry: {
         app: app,
-        vendor: ['material-ui', 'openlayers']
     },
     output: {
         path: BUILD_DIR,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,8 +44,8 @@ var config = {
     module: {
         loaders: [
             {
-                test: /\.jsx?$/,
-                exclude: [/node_modules/, /staticfiles/],
+                test: /\.js?$/,
+                exclude: [/node_modules\/(?!jsts)/, /staticfiles/],
                 loader: ['babel-loader?presets[]=es2015,presets[]=react,presets[]=stage-0'],
             },
             {
@@ -84,8 +84,11 @@ var config = {
 };
 
 if (PROD) {
-    // config.plugins.push(new webpack.DefinePlugin({'process.env': {'NODE_ENV': JSON.stringify('production')}}));
-    // config.plugins.push(new webpack.optimize.UglifyJsPlugin({compressor: {warnings: false}}));
+    config.plugins.push(new webpack.DefinePlugin({'process.env.NODE_ENV': "'production'"}));
+    config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+        compressor: { warnings: false },
+        sourceMap: true,
+    }));
 } else {
     config.entry.app.push('webpack-dev-server/client?http://0.0.0.0:8080')
     config.plugins.push(new webpack.HotModuleReplacementPlugin());


### PR DESCRIPTION
This pr updates our production build process:
1. Removes a global lodash import.
2. Switches the vendor bundle to a bundle of node modules which, once cached, are unlikely to change.
3. Build process will now generate a html file that shows everything in the bundles and helps identify over-sized packages.
4. Disables the redux logger if the env is production (end user should not see the redux logs!)
5. Enables UglifyJS during the webpack production build process. This minifies code and removes dead/unused code, drastically reducing the size of the bundles.
6. Overall these changes take us from combined bundle size of ~7 MB to ~3 MB

Future work: Next we should try to swap out 'openlayers' for 'ol' and take a look at some of the other large deps to see if we can improve/replace them.