### PR TITLE
Allow different file type uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ db_dir
 staticfiles/
 node_modules/
 .DS_Store
+.flowconfig
+.eslintrc.json
 
 
 # Byte-compiled / optimized / DLL files

--- a/config/eventkit-docker.conf
+++ b/config/eventkit-docker.conf
@@ -301,6 +301,8 @@ ServerAdmin you@example.com
         ProxyPassReverse /geocode http://eventkit:6080/geocode
         ProxyPass /configuration http://eventkit:6080/configuration
         ProxyPassReverse /configuration http://eventkit:6080/configuration
+        ProxyPass /file_upload http://eventkit:6080/file_upload
+        ProxyPassReverse /file_upload http://eventkit:6080/file_upload
         ProxyPass /sockjs-node ws://webpack:8080/sockjs-node
         ProxyPassReverse /sockjs-node ws://webpack:8080/sockjs-node
         ProxyPass / http://webpack:8080/

--- a/eventkit_cloud/ui/helpers.py
+++ b/eventkit_cloud/ui/helpers.py
@@ -98,9 +98,9 @@ def get_file_paths(directory):
     return paths
 
 
-def file_to_geojson(file):
+def file_to_geojson(in_memory_file):
     """
-    :param file: A WSGI In memory file
+    :param in_memory_file: A WSGI In memory file
     :return: A geojson object if available
     """
     stage_dir = settings.EXPORT_STAGING_ROOT.rstrip('\/')
@@ -109,21 +109,21 @@ def file_to_geojson(file):
 
     try:
         os.mkdir(dir)
-        file_name = file.name
+        file_name = in_memory_file.name
         file_name, file_extension = os.path.splitext(file_name)
         if not file_name or not file_extension:
             raise Exception('No file type detected')
 
         in_path = os.path.join(dir, 'in_{0}{1}'.format(file_name, file_extension))
         out_path = os.path.join(dir, 'out_{0}.geojson'.format(file_name))
-        write_uploaded_file(file, in_path)
+        write_uploaded_file(in_memory_file, in_path)
 
         if file_extension == '.zip':
             if unzip_file(in_path, dir):
                 has_shp = False
-                for file in os.listdir(dir):
-                    if file.endswith('.shp'):
-                        in_path = os.path.join(dir, file)
+                for unzipped_file in os.listdir(dir):
+                    if unzipped_file.endswith('.shp'):
+                        in_path = os.path.join(dir, unzipped_file)
                         has_shp = True
                         break
                 if not has_shp:
@@ -194,15 +194,15 @@ def unzip_file(fp, dir):
         raise Exception('Could not unzip file')
 
 
-def write_uploaded_file(file, write_path):
+def write_uploaded_file(in_memory_file, write_path):
     """
-    :param file: An WSGI in memory file
+    :param in_memory_file: An WSGI in memory file
     :param write_path: The path which the file should be written to on disk
     :return: True if successful
     """
     try:
         with open(write_path, 'w+') as temp_file:
-            for chunk in file.chunks():
+            for chunk in in_memory_file.chunks():
                 temp_file.write(chunk)
         return True
     except Exception as e:

--- a/eventkit_cloud/ui/helpers.py
+++ b/eventkit_cloud/ui/helpers.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 import os
-import tempfile
 import subprocess
 import zipfile
 import shutil

--- a/eventkit_cloud/ui/helpers.py
+++ b/eventkit_cloud/ui/helpers.py
@@ -2,12 +2,19 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 import os
+import tempfile
+import subprocess
+import zipfile
+import shutil
+import json
 
 from django.conf import settings
 from django.utils import timezone
 from django.template.loader import get_template, render_to_string
-
 from celery.utils.log import get_task_logger
+from ..utils.gdalutils import driver_for
+from uuid import uuid4
+from string import Template
 
 logger = get_task_logger(__name__)
 
@@ -90,3 +97,115 @@ def get_file_paths(directory):
             for f in filenames:
                 paths[os.path.abspath(os.path.join(dirpath, f))] = os.path.join(dirpath, f)
     return paths
+
+
+def file_to_geojson(file):
+    """
+    :param file: A WSGI In memory file
+    :return: A geojson object if available
+    """
+    stage_dir = settings.EXPORT_STAGING_ROOT.rstrip('\/')
+    uid = str(uuid4())
+    dir = os.path.join(stage_dir, uid)
+
+    try:
+        os.mkdir(dir)
+        file_name = file.name
+        file_name, file_extension = os.path.splitext(file_name)
+        if not file_name or not file_extension:
+            raise Exception('No file type detected')
+
+        in_path = os.path.join(dir, 'in_{0}{1}'.format(file_name, file_extension))
+        out_path = os.path.join(dir, 'out_{0}.geojson'.format(file_name))
+        write_uploaded_file(file, in_path)
+
+        if file_extension == '.zip':
+            if unzip_file(in_path, dir):
+                has_shp = False
+                for file in os.listdir(dir):
+                    if file.endswith('.shp'):
+                        in_path = os.path.join(dir, file)
+                        has_shp = True
+                        break
+                if not has_shp:
+                    raise Exception('Zip file does not contain a shp')
+
+        driver, raster = driver_for(in_path)
+
+        if not driver:
+            raise Exception("Could not find the proper driver to handle this file")
+
+        cmd_template = Template("ogr2ogr -f $fmt $out_ds $in_ds")
+
+        cmd = cmd_template.safe_substitute({
+            'fmt': 'geojson',
+            'out_ds': out_path,
+            'in_ds': in_path
+        })
+
+        try:
+            proc = subprocess.Popen(cmd, shell=True, executable='/bin/bash')
+            exitcode = proc.wait()
+        except Exception as e:
+            logger.debug(e)
+            raise Exception('Failed to convert file')
+
+        if os.path.exists(out_path):
+            geojson = read_json_file(out_path)
+            return geojson
+
+        raise Exception('An unknown error occured while processing the file')
+
+    except Exception as e:
+        raise e
+
+    finally:
+        if os.path.exists(dir):
+            shutil.rmtree(dir)
+
+
+def read_json_file(fp):
+    """
+    :param fp: Path to a geojson file
+    :return: A geojson object
+    """
+    try:
+        with open(fp) as file_geojson:
+            geojson = json.load(file_geojson)
+            return geojson
+    except:
+        raise Exception('Unable to read the file')
+
+
+def unzip_file(fp, dir):
+    """
+    :param fp: Path to a zip file 
+    :param dir: Directory where the files should be unzipped to
+    :return: True if successful
+    """
+    if not fp or not dir:
+        return False
+    try:
+        zip = zipfile.ZipFile(fp, 'r')
+        zip.extractall(dir)
+        zip.close()
+        return True
+    except Exception as e:
+        logger.debug(e)
+        raise Exception('Could not unzip file')
+
+
+def write_uploaded_file(file, write_path):
+    """
+    :param file: An WSGI in memory file
+    :param write_path: The path which the file should be written to on disk
+    :return: True if successful
+    """
+    try:
+        with open(write_path, 'w+') as temp_file:
+            for chunk in file.chunks():
+                temp_file.write(chunk)
+        return True
+    except Exception as e:
+        logger.debug(e)
+        raise Exception('Could not write file to disk')

--- a/eventkit_cloud/ui/static/ui/app/actions/mapToolActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/mapToolActions.js
@@ -1,63 +1,58 @@
-import types from './mapToolActionTypes'
 import ol from 'openlayers';
+import axios from 'axios';
+import cookie from 'react-cookie';
 import GeoJSONWriter from 'jsts/org/locationtech/jts/io/GeoJSONWriter';
-import { convertGeoJSONtoJSTS } from '../utils/mapUtils'
+import types from './mapToolActionTypes';
+import { convertGeoJSONtoJSTS } from '../utils/mapUtils';
+
+
+export const ACCEPTED_FILE_TYPES = ['geojson', 'gpkg', 'shp', 'kml', 'zip'];
 
 export function resetGeoJSONFile() {
     return {
-        type: types.FILE_RESET
-    }
+        type: types.FILE_RESET,
+    };
 }
 
-export const processGeoJSONFile = file => dispatch => {
-    dispatch({type: types.FILE_PROCESSING});
+export const processGeoJSONFile = file => (dispatch) => {
+    dispatch({ type: types.FILE_PROCESSING });
     const fileName = file.name;
     const ext = fileName.split('.').pop();
-    if (ext != 'geojson') {
-        const error_msg = 'File must be .geojson NOT .' + ext;
-        dispatch({type: types.FILE_ERROR, error: error_msg});
-        return Promise.reject(new Error(error_msg)).then(function (error) {
-        }, function (error) {
-            console.log(error);
-        });
+    if (ACCEPTED_FILE_TYPES.indexOf(ext) < 0) {
+        const errorMessage = `File type ${ext} is not supported`;
+        dispatch({ type: types.FILE_ERROR, error: errorMessage });
+        return Promise.reject(new Error(errorMessage)).then(() => {});
     }
-    const reader = new FileReader();
-    reader.onload = () => {
-        const dataURL = reader.result;
-        let geojson = null;
-        try {
-            geojson = JSON.parse(dataURL);
-        }
-        catch (e) {
-            dispatch({type: types.FILE_ERROR, error: 'Could not parse GeoJSON'});
-            return Promise.reject(new Error(e)).then(function (error) {
-            }, function (error) {
-                console.log(error);
-            });
-        }
-        try {
-            //Because the UI doesn't support multiple features combine all polygons into one feature.
-            var multipolygon = convertGeoJSONtoJSTS(geojson);
 
-            const writer = new GeoJSONWriter();
-            const geom = (new ol.format.GeoJSON()).readGeometry(writer.write(multipolygon)).transform('EPSG:4326', 'EPSG:3857');
-            if (geom.getType() == 'Polygon' || geom.getType() == 'MultiPolygon') {
-                dispatch({type: types.FILE_PROCESSED, geom: geom});
+    const csrftoken = cookie.load('csrftoken');
+
+    const formData = new FormData();
+    formData.set('file', file);
+
+    return axios({
+        url: '/file_upload',
+        method: 'POST',
+        data: formData,
+        headers: { 'X-CSRFToken': csrftoken },
+    }).then((response) => {
+        const { data } = response;
+        if (data) {
+            try {
+                // Because the UI doesn't support multiple features
+                // combine all polygons into one feature.
+                const multipolygon = convertGeoJSONtoJSTS(data);
+
+                const writer = new GeoJSONWriter();
+                const geom = (new ol.format.GeoJSON()).readGeometry(writer.write(multipolygon)).transform('EPSG:4326', 'EPSG:3857');
+                dispatch({ type: types.FILE_PROCESSED, geom });
+            } catch (err) {
+                dispatch({ type: types.FILE_ERROR, error: 'There was an error processing the geojson file.' });
             }
+        } else {
+            dispatch({ type: types.FILE_ERROR, error: 'No data returned from the api.' });
         }
-        catch (err) {
-            dispatch({type: types.FILE_ERROR, error: 'There was an error processing the geojson file.'});
-            return Promise.reject(new Error(err)).then(function (error) {
-            }, function (error) {
-                console.log(error);
-            });
-        }
-
-    }
-    reader.onerror = () => {
-        dispatch({type: types.FILE_ERROR, error: 'An error was encountered while reading your file'});
-    }
-    reader.readAsText(file);
-    return Promise.resolve();
-}
+    }).catch((error) => {
+        dispatch({ type: types.FILE_ERROR, error: error.response.data });
+    });
+};
 

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
@@ -353,7 +353,7 @@ export class DataPackPage extends React.Component {
                         </div>
                         :
                         <div style={{position: 'relative'}}  className={'qa-DataPackPage-view'}>
-                            {this.state.loading || this.props.runsDeletion.deleting ? 
+                            {this.state.loading || this.props.runsDeletion.deleting || this.props.importGeom.processing ? 
                             <div style={{zIndex: 10, position: 'absolute', width: '100%', height: '100%',  backgroundColor: 'rgba(0,0,0,0.2)'}}>
                                 <div style={{width: '100%', height: '100%', display: 'inline-flex'}}>
                                     <CircularProgress 

--- a/eventkit_cloud/ui/static/ui/app/components/MapTools/DropZoneDialog.js
+++ b/eventkit_cloud/ui/static/ui/app/components/MapTools/DropZoneDialog.js
@@ -1,7 +1,8 @@
-import React, {Component, PropTypes} from 'react';
+import React, { Component, PropTypes } from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
-import BaseDialog from '../BaseDialog';
 import FileFileUpload from 'material-ui/svg-icons/file/file-upload';
+import BaseDialog from '../BaseDialog';
+
 const Dropzone = require('react-dropzone');
 
 export class DropZoneDialog extends Component {
@@ -14,7 +15,7 @@ export class DropZoneDialog extends Component {
     }
 
     onDrop(acceptedFiles) {
-        if(acceptedFiles.length == 1) {
+        if (acceptedFiles.length === 1) {
             const file = acceptedFiles[0];
             this.props.setImportModalState(false);
             this.props.processGeoJSONFile(file);
@@ -29,7 +30,7 @@ export class DropZoneDialog extends Component {
         this.props.setImportModalState(false);
         this.props.setAllButtonsDefault();
     }
-    
+
     render() {
         const styles = {
             drop: {
@@ -39,49 +40,52 @@ export class DropZoneDialog extends Component {
                 textAlign: 'center',
                 border: '1px dashed',
                 fontSize: '1em',
-                color: '#4498c0'
+                color: '#4498c0',
             },
             text: {
                 verticalAlign: 'center',
                 color: 'grey',
                 height: '100px',
-                marginTop: '50px'
-            }
-        }
+                marginTop: '50px',
+            },
+        };
 
-        return(
+        return (
             <BaseDialog
                 show={this.props.showImportModal}
                 onClose={this.handleClear}
-                title={'Import AOI'}
+                title="Import AOI"
                 actions={[]}
-                bodyStyle={{paddingBottom: '50px'}}
-                className={'qa-DropZoneDialog-BaseDialog'}
+                bodyStyle={{ paddingBottom: '50px' }}
+                className="qa-DropZoneDialog-BaseDialog"
             >
-                <Dropzone 
-                    onDrop={this.onDrop} 
-                    multiple={false} 
+                <Dropzone
+                    onDrop={this.onDrop}
+                    multiple={false}
                     style={styles.drop}
-                    ref={(node) => {this.dropzone = node;}} 
-                    disableClick={true}
-                    maxSize={2000000}
-                    className={'qa-DropZoneDialog-Dropzone'}
+                    ref={(node) => { this.dropzone = node; }}
+                    disableClick
+                    maxSize={5000000}
+                    className="qa-DropZoneDialog-Dropzone"
                 >
-                    <div style={styles.text} className={'qa-DropZoneDialog-text'}>
-                        <span><strong>GeoJSON</strong> format only, <strong>2MB</strong> max,<br/>Drag and drop or<br/></span>
+                    <div style={styles.text} className="qa-DropZoneDialog-text">
+                        <span>
+                            <strong>GeoJSON, KML, GPKG, or zipped SHP </strong>
+                            formats only, <strong>5 MB</strong> max,<br />Drag and drop or<br />
+                        </span>
                         <RaisedButton
-                            style={{margin: '15px 5px 10px'}}
-                            labelStyle={{color: 'whitesmoke'}}
-                            backgroundColor={'#4598bf'}
-                            label={'Select A File'}
-                            icon={<FileFileUpload/>}
+                            style={{ margin: '15px 5px 10px' }}
+                            labelStyle={{ color: 'whitesmoke' }}
+                            backgroundColor="#4598bf"
+                            label="Select A File"
+                            icon={<FileFileUpload />}
                             onClick={this.onOpenClick}
-                            className={'qa-DropZoneDialog-RaisedButton-select'}
+                            className="qa-DropZoneDialog-RaisedButton-select"
                         />
                     </div>
                 </Dropzone>
             </BaseDialog>
-        )
+        );
     }
 }
 
@@ -90,6 +94,6 @@ DropZoneDialog.propTypes = {
     setAllButtonsDefault: PropTypes.func,
     setImportModalState: PropTypes.func,
     processGeoJSONFile: PropTypes.func,
-}
+};
 
 export default DropZoneDialog;

--- a/eventkit_cloud/ui/static/ui/app/tests/MapTools/DropZoneDialog.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/MapTools/DropZoneDialog.spec.js
@@ -37,7 +37,8 @@ describe('DropZoneDialog component', () => {
         });
         expect(children.find(Dropzone)).toHaveLength(1);
         expect(children.find('.qa-DropZoneDialog-text')).toHaveLength(1);
-        expect(children.find('.qa-DropZoneDialog-text').find('span').first().text()).toEqual('GeoJSON format only, 2MB max,Drag and drop or');
+        expect(children.find('.qa-DropZoneDialog-text').find('span').first().text())
+            .toEqual('GeoJSON, KML, GPKG, or zipped SHP formats only, 5 MB max,Drag and drop or');
         expect(children.find('.qa-DropZoneDialog-RaisedButton-select')).toHaveLength(1);
         expect(children.find(FileFileUpload)).toHaveLength(1);
     });

--- a/eventkit_cloud/ui/static/ui/app/tests/actions/DataPackPageActions.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/actions/DataPackPageActions.spec.js
@@ -4,7 +4,6 @@ import * as actions from '../../actions/DataPackPageActions';
 import types from '../../actions/actionTypes';
 import React from 'react';
 import axios from 'axios';
-import expect from 'expect';
 import MockAdapter from 'axios-mock-adapter';
 
 const middlewares = [thunk];

--- a/eventkit_cloud/ui/static/ui/app/tests/actions/mapToolActions.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/actions/mapToolActions.spec.js
@@ -1,8 +1,12 @@
 import configureMockStore from 'redux-mock-store';
+import ol from 'openlayers';
 import thunk from 'redux-thunk';
+import axios from 'axios';
+import sinon from 'sinon';
+import MockAdapter from 'axios-mock-adapter';
 import * as actions from '../../actions/mapToolActions';
-import { convertGeoJSONtoJSTS } from '../../utils/mapUtils'
-import types from '../../actions/mapToolActionTypes'
+import types from '../../actions/mapToolActionTypes';
+
 
 const middlewares = [thunk];
 const mockStore = configureMockStore(middlewares);
@@ -10,99 +14,155 @@ const mockStore = configureMockStore(middlewares);
 describe('mapTool actions', () => {
     it('resetGeoJSONFile should return type FILE_RESET', () => {
         expect(actions.resetGeoJSONFile()).toEqual({
-            type: 'FILE_RESET'
+            type: 'FILE_RESET',
         });
     });
 
-    it('processGeoJSONFile should create error if extension is not geojson ', () => {
-        // Initialize mockstore with empty state
-        const initialState = {}
-        const store = mockStore(initialState)
-        const file = new File(["<!doctype html><div>file</div>"],
-            "test.shp",
-            {"type": "text/html"}
-        )
-        // Test if your store dispatched the expected actions
-        const expectedPayload = [{type: types.FILE_PROCESSING},
-            {type: types.FILE_ERROR, error: 'File must be .geojson NOT .shp'}]
-        store.dispatch(actions.processGeoJSONFile(file))
+    it('processGeoJSONFile should create error if extension is not an accepted file type ', () => {
+        const initialState = {};
+        const store = mockStore(initialState);
+        const file = new File(
+            ['<!doctype html><div>file</div>'],
+            'test.wkt',
+            { type: 'text/html' },
+        );
+        const expectedPayload = [
+            { type: types.FILE_PROCESSING },
+            { type: types.FILE_ERROR, error: 'File type wkt is not supported' },
+        ];
+        return store.dispatch(actions.processGeoJSONFile(file))
             .catch(() => {
-                expect(store.getActions()).toEqual(expectedPayload)
-            })
-    });
-
-    it('processGeoJSONFile should raise error if not a json', () => {
-        // Initialize mockstore with empty state
-        const initialState = {}
-        const store = mockStore(initialState)
-        const file = new File(["Data"],
-            "test.geojson",
-            {"type": "application/json"}
-        )
-
-        // Test if your store dispatched the expected actions
-        const expectedPayload = [{type: types.FILE_PROCESSING},
-            {type: types.FILE_ERROR, error: 'Could not parse GeoJSON'}]
-        store.dispatch(actions.processGeoJSONFile(file))
-            .catch(() => {
-                expect(store.getActions()).toEqual(expectedPayload)
-            })
+                expect(store.getActions()).toEqual(expectedPayload);
+            });
     });
 
     it('processGeoJSONFile should add AOI to state if valid geojson', () => {
-        // Initialize mockstore with empty state
-        const initialState = {}
-        const store = mockStore(initialState)
-        const point = {"type": "Point", "coordinates": [100.0, 0.0]};
-        const returnedGeom = convertGeoJSONtoJSTS(point)
-        const file = new File([point],
-            "test.geojson",
-            {"type": "application/json"}
-        )
+        const geojson = {
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature',
+                    properties: {},
+                    geometry: {
+                        type: 'Polygon',
+                        coordinates: [
+                            [
+                                [7.2, 46.2],
+                                [7.6, 46.2],
+                                [7.6, 46.6],
+                                [7.2, 46.6],
+                                [7.2, 46.2],
+                            ],
+                        ],
+                    },
+                },
+            ],
+        };
+        const initialState = {};
+        const store = mockStore(initialState);
+        const geom = (new ol.format.GeoJSON()).readGeometry(geojson.features[0].geometry);
+        const readGeomStub = sinon.stub(ol.format.GeoJSON.prototype, 'readGeometry')
+            .returns(geom);
+        const mock = new MockAdapter(axios, { delayResponse: 10 });
+        mock.onPost('/file_upload').reply(200, geojson);
+        const file = new File(
+            [geojson],
+            'test.geojson',
+            { type: 'application/json' },
+        );
 
-        // Test if your store dispatched the expected actions
-        const expectedPayload = [{type: types.FILE_PROCESSING},
-            {type: types.FILE_PROCESSED, geom: returnedGeom}]
-        store.dispatch(actions.processGeoJSONFile(file))
-            .catch(() => {
-                expect(store.getActions()).toEqual(expectedPayload)
-            })
+        const expectedPayload = [
+            { type: types.FILE_PROCESSING },
+            { type: types.FILE_PROCESSED, geom },
+        ];
+        return store.dispatch(actions.processGeoJSONFile(file))
+            .then(() => {
+                expect(store.getActions()).toEqual(expectedPayload);
+                readGeomStub.restore();
+            });
     });
 
     it('processGeoJSONFile should not add AOI to state if invalid geojson', () => {
-        // Initialize mockstore with empty state
-        const initialState = {}
-        const store = mockStore(initialState)
-        const point = {"type": "point", "coordinates": [100.0, 0.0]};
-        const file = new File([point],
-            "test.geojson",
-            {"type": "application/json"}
-        )
+        const geojson = {
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature',
+                    properties: {},
+                    geometry: {
+                        type: 'polygon',
+                        coordinates: [
+                            [
+                                [7.2, 46.2],
+                                [7.6, 46.2],
+                                [7.6, 46.6],
+                                [7.2, 46.6],
+                                [7.2, 46.2],
+                            ],
+                        ],
+                    },
+                },
+            ],
+        };
+        const initialState = {};
+        const store = mockStore(initialState);
+        const mock = new MockAdapter(axios, { delayResponse: 10 });
+        mock.onPost('/file_upload').reply(200, geojson);
+        const file = new File(
+            [geojson],
+            'test.geojson',
+            { type: 'application/json' },
+        );
 
-        // Test if your store dispatched the expected actions
-        const expectedPayload = [{type: types.FILE_PROCESSING},
-            {type: types.FILE_ERROR, error: 'There was an error processing the geojson file.'}]
-        store.dispatch(actions.processGeoJSONFile(file))
-            .catch(() => {
-                expect(store.getActions()).toEqual(expectedPayload)
-            })
+        const expectedPayload = [
+            { type: types.FILE_PROCESSING },
+            { type: types.FILE_ERROR, error: 'There was an error processing the geojson file.' },
+        ];
+        return store.dispatch(actions.processGeoJSONFile(file))
+            .then(() => {
+                expect(store.getActions()).toEqual(expectedPayload);
+            });
     });
 
-    it('processGeoJSONFile should dispatch error onerror', () => {
-        // Initialize mockstore with empty state
-        const initialState = {}
-        const store = mockStore(initialState)
-        const file = new File(['not a file'],
-            "test.geojson",
-            {"type": "application/json"}
-        )
+    it('processGeoJSONFile should dispatch error if no data is returned in the response', () => {
+        const initialState = {};
+        const store = mockStore(initialState);
+        const mock = new MockAdapter(axios, { delayResponse: 10 });
+        mock.onPost('/file_upload').reply(200, null);
+        const file = new File(
+            [{}],
+            'test.geojson',
+            { type: 'application/json' },
+        );
 
-        // Test if your store dispatched the expected actions
-        const expectedPayload = [{type: types.FILE_PROCESSING},
-            {type: types.FILE_ERROR, error: 'There was an error processing the geojson file.'}]
-        store.dispatch(actions.processGeoJSONFile(file))
-            .catch(() => {
-                expect(store.getActions()).toEqual(expectedPayload)
-            })
+        const expectedPayload = [
+            { type: types.FILE_PROCESSING },
+            { type: types.FILE_ERROR, error: 'No data returned from the api.' },
+        ];
+        return store.dispatch(actions.processGeoJSONFile(file))
+            .then(() => {
+                expect(store.getActions()).toEqual(expectedPayload);
+            });
+    });
+
+    it('processGeoJSONFile should dispatch error on axios error', () => {
+        const initialState = {};
+        const store = mockStore(initialState);
+        const mock = new MockAdapter(axios, { delayResponse: 10 });
+        mock.onPost('/file_upload').reply(400, 'whoops');
+        const file = new File(
+            ['not a file'],
+            'test.geojson',
+            { type: 'application/json' },
+        );
+
+        const expectedPayload = [
+            { type: types.FILE_PROCESSING },
+            { type: types.FILE_ERROR, error: 'whoops' },
+        ];
+        return store.dispatch(actions.processGeoJSONFile(file))
+            .then(() => {
+                expect(store.getActions()).toEqual(expectedPayload);
+            });
     });
 });

--- a/eventkit_cloud/ui/tests/test_helpers.py
+++ b/eventkit_cloud/ui/tests/test_helpers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import tempfile
 
 from django.test import TestCase
 

--- a/eventkit_cloud/ui/tests/test_helpers.py
+++ b/eventkit_cloud/ui/tests/test_helpers.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import logging
+import tempfile
 
 from django.test import TestCase
 
 import os
-from mock import Mock, patch, call
-from ..helpers import cd, get_style_files, get_file_paths
+from mock import Mock, patch, call, mock_open
+from ..helpers import cd, get_style_files, get_file_paths, file_to_geojson, \
+    read_json_file, unzip_file, write_uploaded_file
 
 logger = logging.getLogger(__name__)
 
@@ -25,3 +27,141 @@ class TestHelpers(TestCase):
 
     def test_get_file_paths(self):
         self.assertTrue(os.path.abspath(__file__) in get_file_paths(os.path.dirname(__file__)))
+
+    @patch('eventkit_cloud.ui.helpers.os.path.splitext')
+    @patch('eventkit_cloud.ui.helpers.shutil.rmtree')
+    @patch('eventkit_cloud.ui.helpers.read_json_file')
+    @patch('eventkit_cloud.ui.helpers.os.path.exists')
+    @patch('eventkit_cloud.ui.helpers.subprocess')
+    @patch('eventkit_cloud.ui.helpers.driver_for')
+    @patch('eventkit_cloud.ui.helpers.os.listdir')
+    @patch('eventkit_cloud.ui.helpers.unzip_file')
+    @patch('eventkit_cloud.ui.helpers.write_uploaded_file')
+    @patch('eventkit_cloud.ui.helpers.os.mkdir')
+    @patch('eventkit_cloud.ui.helpers.uuid4')
+    def test_file_to_geojson(self, uid, makedir, write, unzip, listdirs, driver, subproc, exists, reader, rm, split):
+        geojson = {'type': 'FeatureCollection', 'other_stuff': {}}
+        file = Mock()
+        file.name = 'test_file.geojson'
+        split.return_value = 'test_file', '.geojson'
+        uid.return_value = 12345
+        makedir.return_value = True
+        write.return_value = True
+        unzip.return_value = False
+        listdirs.return_value = []
+        driver.return_value = ('GeoJSON', False)
+        proc = Mock()
+        proc.wait = Mock()
+        subproc.Popen.return_value = proc
+        exists.return_value = True
+        reader.return_value = geojson
+        with self.settings(
+            EXPORT_STAGING_ROOT='/var/lib/stage'
+        ):
+            # It should run through the entire process for a geojson file and return it
+            dir = '/var/lib/stage/12345'
+            expected_file_name, expected_file_ext = os.path.splitext(file.name)
+            expected_in_path = os.path.join(dir, 'in_{0}{1}'.format(expected_file_name, expected_file_ext))
+            expected_out_path = os.path.join(dir, 'out_{0}.geojson'.format(expected_file_name))
+            ret = file_to_geojson(file)
+            self.assertEquals(ret, geojson)
+            makedir.assert_called_once_with(dir)
+            write.assert_called_once_with(file, expected_in_path)
+            driver.assert_called_once_with(expected_in_path)
+            expected_cmd = "ogr2ogr -f geojson {0} {1}".format(expected_out_path, expected_in_path)
+            subproc.Popen.assert_called_once_with(expected_cmd, shell=True, executable='/bin/bash')
+            rm.assert_called_once_with(dir)
+
+
+            # It should run through the entire process for a zip shp and return a geojson
+            file.name = 'something.zip'
+            split.return_value = 'something', '.zip'
+            unzip.return_value = True
+            expected_file_name, expected_file_ext = os.path.splitext(file.name)
+            expected_in_path = os.path.join(dir, 'in_{0}{1}'.format(expected_file_name, expected_file_ext))
+            expected_out_path = os.path.join(dir, 'out_{0}.geojson'.format(expected_file_name))
+            listdirs.return_value = ['something.shp']
+            updated_in_path = os.path.join(dir, 'something.shp')
+            updated_cmd = 'ogr2ogr -f geojson {0} {1}'.format(expected_out_path, updated_in_path)
+            ret = file_to_geojson(file)
+            self.assertEquals(ret, geojson)
+            unzip.assert_called_once_with(expected_in_path, dir)
+            listdirs.assert_called_with(dir)
+            driver.assert_called_with(updated_in_path)
+            subproc.Popen.called_with(updated_cmd, shell=True, executable='/bin/bash')
+
+            # It should raise an exception if there is no file extension
+            file.name = 'something'
+            split.return_value = 'something', ''
+            self.assertRaises(Exception, file_to_geojson, file)
+
+            # It should raise an exception if zip does not contain shp
+            file.name = 'thing.zip'
+            split.return_value = 'thing', '.zip'
+            unzip.return_value = True
+            listdirs.return_value = ['thing.dbf', 'thing.prj']
+            self.assertRaises(Exception, file_to_geojson, file)
+
+            # It should raise an exception if no driver can be found
+            file.name = 'test.geojson'
+            split.return_value = 'test', '.geojson'
+            driver.return_value = None, None
+            self.assertRaises(Exception, file_to_geojson, file)
+
+            # It should raise an exception if the subprocess throws one
+            driver.return_value = 'GeoJSON', False
+            subproc.Popen.side_effect = Exception('doh!')
+            self.assertRaises(Exception, file_to_geojson, file)
+
+            # It should raise and exception if output file does not exist
+            subproc.Popen.side_effect = None
+            exists.return_value = False
+            self.assertRaises(Exception, file_to_geojson, file)
+
+    @patch('eventkit_cloud.ui.helpers.json')
+    def test_read_json_file(self, fake_json):
+        file_path = '/path/to/file.geojson'
+        geojson = {'type': 'FeatureCollection', 'other_stuff': {}}
+        fake_json.load.return_value = geojson
+        with patch('eventkit_cloud.ui.helpers.open', new_callable=mock_open()) as m:
+            ret = read_json_file(file_path)
+            self.assertEquals(ret, geojson)
+            m.assert_called_once_with(file_path)
+            fake_json.load.assert_called_once_with(m.return_value.__enter__.return_value)
+
+            m.side_effect = Exception('Thats not right!')
+            self.assertRaises(Exception, read_json_file, file_path)
+
+
+    @patch('eventkit_cloud.ui.helpers.zipfile')
+    def test_unzip_file(self, zipfile):
+        mock_zip = Mock()
+        mock_zip.extractall = Mock()
+        mock_zip.close = Mock()
+        zipfile.ZipFile.return_value = mock_zip
+
+        file_path = '/path/to/file.txt'
+        directory = '/path/to'
+
+        ret = unzip_file(file_path, directory)
+        self.assertTrue(ret)
+        zipfile.ZipFile.assert_called_once_with(file_path, 'r')
+        mock_zip.extractall.assert_called_once_with(directory)
+        mock_zip.close.assert_called_once
+
+        mock_zip.extractall.side_effect = Exception('oh no!')
+        self.assertRaises(Exception, unzip_file, file_path, directory)
+
+    def test_write_uploaded_file(self):
+        with patch('eventkit_cloud.ui.helpers.open', new_callable=mock_open()) as m:
+            test_file = Mock()
+            test_file.chunks = Mock(return_value=['1', '2','3','4','5'])
+            file_path = '/path/to/file.txt'
+            ret = write_uploaded_file(test_file, file_path)
+            self.assertTrue(ret)
+            m.assert_called_once_with(file_path, 'w+')
+            test_file.chunks.assert_called_once
+            self.assertEqual(m.return_value.__enter__.return_value.write.call_count, 5)
+
+            m.side_effect = Exception('whoops!')
+            self.assertRaises(Exception, write_uploaded_file, test_file, file_path)

--- a/eventkit_cloud/ui/urls.py
+++ b/eventkit_cloud/ui/urls.py
@@ -4,7 +4,7 @@ from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 from django.views.decorators.csrf import ensure_csrf_cookie
-from .views import logout, data_estimator, auth, geocode, get_config
+from .views import logout, data_estimator, auth, geocode, get_config, convert_to_geojson
 from django.conf import settings
 
 urlpatterns = [
@@ -19,6 +19,7 @@ urlpatterns = [
     url(r'^estimator/?$', login_required(data_estimator)),
     url(r'^geocode/?$', login_required(geocode)),
     url(r'^configuration/?$', get_config),
+    url(r'^file_upload/?$', login_required(convert_to_geojson)),
 ]
 
 urlpatterns += [

--- a/eventkit_cloud/ui/views.py
+++ b/eventkit_cloud/ui/views.py
@@ -15,6 +15,9 @@ from ..api.serializers import UserDataSerializer
 from rest_framework.renderers import JSONRenderer
 from logging import getLogger
 from ..utils.geocode import Geocode
+from .helpers import file_to_geojson
+
+
 
 logger = getLogger(__file__)
 
@@ -203,6 +206,19 @@ def get_config(request):
 
     return HttpResponse(json.dumps(config), status=200)
 
+
+@require_http_methods(['POST'])
+def convert_to_geojson(request):
+    file = request.FILES.get('file', None)
+    if not file:
+        return HttpResponse('No file supplied in the POST request', status=400)
+    try:
+        geojson = file_to_geojson(file)
+        return HttpResponse(json.dumps(geojson), status=200)
+    except Exception as e:
+        return HttpResponse(e.message, status=400)
+
+
 # error views
 @require_http_methods(['GET'])
 def create_error_view(request):
@@ -219,4 +235,3 @@ def not_found_error_view(request):
 
 def not_allowed_error_view(request):
     return render_to_response('ui/403.html', {}, RequestContext(request), status=403)
-

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -27,7 +27,8 @@ def open_ds(ds_path):
 
     try:
         gdal_dataset = gdal.Open(ds_path)
-        return gdal_dataset
+        if gdal_dataset:
+            return gdal_dataset
     except RuntimeError as ex:
         if ('not recognized as a supported file format' not in ex.message) or \
                 ('Error browsing database for PostGIS Raster tables' in ex.message):


### PR DESCRIPTION
This pr updates how imported files are handled. Now they are sent to the backend and converted to geojson format. The importer supports GPKG, KML, GeoJSON, or a zipped SHP. 
![image](https://user-images.githubusercontent.com/16799449/31412204-3d0f178c-ade2-11e7-8d1e-006121fb98cd.png)
