### PR TITLE
223 fix oauth logout

### DIFF
--- a/eventkit_cloud/auth/urls.py
+++ b/eventkit_cloud/auth/urls.py
@@ -5,9 +5,11 @@ from __future__ import absolute_import
 from .views import oauth, callback, logout
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.conf.urls import url
+from django.views.decorators.cache import never_cache
+
 
 urlpatterns = [
     url(r'^oauth$', ensure_csrf_cookie(oauth), name='oauth'),
     url(r'^callback$', ensure_csrf_cookie(callback), name='callback'),
-    url(r'^logout$', ensure_csrf_cookie(logout), name='logout')
+    url(r'^logout$', never_cache(ensure_csrf_cookie(logout)), name='logout')
 ]

--- a/eventkit_cloud/auth/views.py
+++ b/eventkit_cloud/auth/views.py
@@ -7,20 +7,17 @@ from ..core.helpers import get_id
 from django.contrib.auth import login
 import urllib
 from django.shortcuts import redirect
-from ..api.serializers import UserDataSerializer
-from rest_framework.renderers import JSONRenderer
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 import json
 from django.contrib.auth import logout as auth_logout
-from datetime import datetime
 
 from logging import getLogger
 
 logger = getLogger(__name__)
 
+
 def oauth(request):
     """
-
     :return: A redirection to the OAuth server (OAUTH_AUTHORIZATION_URL) provided in the settings 
     """
     if getattr(settings, "OAUTH_AUTHORIZATION_URL", None):
@@ -39,6 +36,7 @@ def oauth(request):
     else:
         return HttpResponse(status=400)
 
+
 def callback(request):
     access_token = request_access_token(request.GET.get('code'))
     user = fetch_user_from_token(access_token)
@@ -49,18 +47,25 @@ def callback(request):
     else:
         logger.error('User could not be logged in.')
         return HttpResponse('{"error":"User could not be logged in"}',
-                        content_type="application/json",
-                        status=401)
+                            content_type="application/json",
+                            status=401)
+
 
 def logout(request):
-    """Logs out user"""
+    """Log out user
+
+        If user is an Oauth user it will pass back an OAuth redirect to be handled by UI.
+    """
+    is_oauth = hasattr(request.user, 'oauth')
     auth_logout(request)
+    response = redirect('login')
     if getattr(settings, "OAUTH_LOGOUT_URL", None):
-        response = HttpResponse(json.dumps({"OAUTH_LOGOUT_URL":settings.OAUTH_LOGOUT_URL}),
-                        content_type="application/json",
-                        status=200)
-    else:
-        response = redirect('login')
+        import sys
+        print("USER HAS OAUTH: {0}".format(is_oauth))
+        sys.stdout.flush()
+        logger.error("USER HAS OAUTH: {0}".format(is_oauth))
+        if is_oauth:
+            response = JsonResponse({'OAUTH_LOGOUT_URL': settings.OAUTH_LOGOUT_URL})
 
     if settings.SESSION_USER_LAST_ACTIVE_AT in request.session:
         del request.session[settings.SESSION_USER_LAST_ACTIVE_AT]

--- a/eventkit_cloud/auth/views.py
+++ b/eventkit_cloud/auth/views.py
@@ -56,7 +56,9 @@ def logout(request):
     """Logs out user"""
     auth_logout(request)
     if getattr(settings, "OAUTH_LOGOUT_URL", None):
-        response = redirect(settings.OAUTH_LOGOUT_URL)
+        response = HttpResponse(json.dumps({"OAUTH_LOGOUT_URL":settings.OAUTH_LOGOUT_URL}),
+                        content_type="application/json",
+                        status=200)
     else:
         response = redirect('login')
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -264,7 +264,6 @@ class ExportTask(LockingTask):
             einfo = ExceptionInfo()
             self.on_failure(e, task_uid, args, kwargs, einfo)
 
-
     @transaction.atomic
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """

--- a/eventkit_cloud/ui/static/ui/app/actions/userActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActions.js
@@ -4,13 +4,16 @@ import cookie from 'react-cookie';
 import actions from './actionTypes';
 
 export const logout = query => (dispatch) => {
-    return axios('/logout', { method: 'GET' }).then(() => {
+    return axios('/logout', { method: 'GET' }).then((response) => {
         dispatch({
             type: actions.USER_LOGGED_OUT,
         });
-        // if (typeof query === 'undefined') {
-        //     dispatch(push({ pathname: '/login' }));
-        // }
+        if(response.data){
+            window.location.href = response.data.OAUTH_LOGOUT_URL;
+        };
+        if (typeof query === 'undefined') {
+            dispatch(push({ pathname: '/login' }));
+        };
     }).catch((error) => {
         console.log(error);
     });
@@ -44,11 +47,16 @@ export const login = (data, query) => (dispatch) => {
                 type: actions.USER_LOGGED_IN,
                 payload: response.data,
             });
-        } else {
-            dispatch(logout(query));
+        }
+        else {
+            dispatch({
+                type: actions.USER_LOGGED_OUT,
+            });
         }
     }).catch(() => {
-        dispatch(logout(query));
+        dispatch({
+            type: actions.USER_LOGGED_OUT,
+        });
     });
 };
 

--- a/eventkit_cloud/ui/static/ui/app/actions/userActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActions.js
@@ -3,15 +3,15 @@ import axios from 'axios';
 import cookie from 'react-cookie';
 import actions from './actionTypes';
 
+
 export const logout = query => (dispatch) => {
     return axios('/logout', { method: 'GET' }).then((response) => {
         dispatch({
             type: actions.USER_LOGGED_OUT,
         });
-        if(response.data){
+        if(response.data.OAUTH_LOGOUT_URL) {
             window.location.href = response.data.OAUTH_LOGOUT_URL;
-        };
-        if (typeof query === 'undefined') {
+        }else{
             dispatch(push({ pathname: '/login' }));
         };
     }).catch((error) => {

--- a/eventkit_cloud/ui/static/ui/app/actions/userActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActions.js
@@ -8,9 +8,9 @@ export const logout = query => (dispatch) => {
         dispatch({
             type: actions.USER_LOGGED_OUT,
         });
-        if (typeof query === 'undefined') {
-            dispatch(push({ pathname: '/login' }));
-        }
+        // if (typeof query === 'undefined') {
+        //     dispatch(push({ pathname: '/login' }));
+        // }
     }).catch((error) => {
         console.log(error);
     });

--- a/eventkit_cloud/ui/urls.py
+++ b/eventkit_cloud/ui/urls.py
@@ -5,24 +5,24 @@ from django.contrib.auth.decorators import login_required
 from django.views.generic import TemplateView
 from django.views.decorators.csrf import ensure_csrf_cookie
 from .views import logout, data_estimator, auth, geocode, get_config, convert_to_geojson, user_active
-from django.conf import settings
+from django.views.decorators.cache import never_cache
 
 urlpatterns = [
-    url(r'^login', ensure_csrf_cookie(TemplateView.as_view(template_name='ui/index.html')), name='login'),
-    url(r'^/?$', login_required(TemplateView.as_view(template_name='ui/index.html')), name="home"),
-    url(r'^exports/?$', login_required(TemplateView.as_view(template_name='ui/index.html')), name="exports"),
-    url(r'^status', login_required(TemplateView.as_view(template_name='ui/index.html')), name="status"),
-    url(r'^create/?$', login_required(TemplateView.as_view(template_name='ui/index.html')), name="create"),
-    url(r'^account', login_required(TemplateView.as_view(template_name='ui/index.html')), name="account"),
-    url(r'^about', login_required(TemplateView.as_view(template_name='ui/index.html')), name="about"),
-    url(r'^logout', login_required(logout), name="logout"),
-    url(r'^estimator/?$', login_required(data_estimator)),
-    url(r'^geocode/?$', login_required(geocode)),
-    url(r'^configuration/?$', get_config),
-    url(r'^file_upload/?$', login_required(convert_to_geojson)),
-    url(r'^user_active$', login_required(user_active), name='user_active'),
+    url(r'^login', never_cache(ensure_csrf_cookie(TemplateView.as_view(template_name='ui/index.html'))), name='login'),
+    url(r'^/?$', never_cache(login_required(TemplateView.as_view(template_name='ui/index.html'))), name="home"),
+    url(r'^exports/?$', never_cache(login_required(TemplateView.as_view(template_name='ui/index.html'))), name="exports"),
+    url(r'^status', never_cache(login_required(TemplateView.as_view(template_name='ui/index.html'))), name="status"),
+    url(r'^create/?$', never_cache(login_required(TemplateView.as_view(template_name='ui/index.html'))), name="create"),
+    url(r'^account', never_cache(login_required(TemplateView.as_view(template_name='ui/index.html'))), name="account"),
+    url(r'^about', never_cache(login_required(TemplateView.as_view(template_name='ui/index.html'))), name="about"),
+    url(r'^logout', never_cache(login_required(logout)), name="logout"),
+    url(r'^estimator/?$', never_cache(login_required(data_estimator))),
+    url(r'^geocode/?$', never_cache(login_required(geocode))),
+    url(r'^configuration/?$', never_cache(get_config)),
+    url(r'^file_upload/?$', never_cache(login_required(convert_to_geojson))),
+    url(r'^user_active$', never_cache(login_required(user_active)), name='user_active'),
 ]
 
 urlpatterns += [
-    url(r'^auth$', ensure_csrf_cookie(auth), name='auth'),
+    url(r'^auth$', never_cache(ensure_csrf_cookie(auth)), name='auth'),
     ]

--- a/eventkit_cloud/ui/views.py
+++ b/eventkit_cloud/ui/views.py
@@ -213,7 +213,6 @@ def get_config(request):
     """
     config = getattr(settings, 'UI_CONFIG', {})
     config["MAX_EXPORTRUN_EXPIRATION_DAYS"] = getattr(settings, 'MAX_EXPORTRUN_EXPIRATION_DAYS')
-    config["OAUTH_LOGOUT_URL"] = getattr(settings, "OAUTH_LOGOUT_URL")
 
     return HttpResponse(json.dumps(config), status=200)
 

--- a/eventkit_cloud/ui/views.py
+++ b/eventkit_cloud/ui/views.py
@@ -213,6 +213,7 @@ def get_config(request):
     """
     config = getattr(settings, 'UI_CONFIG', {})
     config["MAX_EXPORTRUN_EXPIRATION_DAYS"] = getattr(settings, 'MAX_EXPORTRUN_EXPIRATION_DAYS')
+    config["OAUTH_LOGOUT_URL"] = getattr(settings, "OAUTH_LOGOUT_URL")
 
     return HttpResponse(json.dumps(config), status=200)
 

--- a/eventkit_cloud/utils/tests/files/query.osm
+++ b/eventkit_cloud/utils/tests/files/query.osm
@@ -1,1 +1,0 @@
-<osm>some data</osm>


### PR DESCRIPTION
OAuth providers often sometimes a browser redirect to fully logout a user from the Oauth session (not merely an async call).  This change will now redirect users if `OAUTH_LOGOUT_URL` is set.  

To test set `OAUTH_LOGOUT_URL` to a valid url.  Login to the application, and then click logout, you should be redirected to the LOGOUT_URL.  When navigating back to the application, you should be prompted to login. 