### PR TITLE
234 runs request bug

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/actions/DataPackPageActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/DataPackPageActions.js
@@ -1,18 +1,31 @@
-import types from './actionTypes';
 import axios from 'axios';
 import cookie from 'react-cookie';
+import types from './actionTypes';
 
 export function getRuns(params, geojson) {
-    let thunk = dispatch => {
-        dispatch({type: types.FETCHING_RUNS});
-        const url = params ? `/api/runs/filter?${params}` : '/api/runs/filter'
+    return (dispatch, getState) => {
+        const { runsList } = getState();
+        if (runsList.fetching && runsList.cancelSource) {
+            // if there is already a request in process we need to cancel it
+            // before executing the current request
+            runsList.cancelSource.cancel('Request is no longer valid, cancelling');
+        }
+
+        const { CancelToken } = axios;
+        const source = CancelToken.source();
+
+        dispatch({ type: types.FETCHING_RUNS, cancelSource: source });
+
+        const url = params ? `/api/runs/filter?${params}` : '/api/runs/filter';
         const csrfmiddlewaretoken = cookie.load('csrftoken');
-        const data = geojson ? {geojson: JSON.stringify(geojson)} : {}
-        return axios ({
-            url: url,
+        const data = geojson ? { geojson: JSON.stringify(geojson) } : { };
+
+        return axios({
+            url,
             method: 'POST',
-            data: data,
-            headers: {"X-CSRFToken": csrfmiddlewaretoken}
+            data,
+            headers: { 'X-CSRFToken': csrfmiddlewaretoken },
+            cancelToken: source.token,
         }).then((response) => {
             let nextPage = false;
             let links = [];
@@ -20,36 +33,30 @@ export function getRuns(params, geojson) {
             if (response.headers.link) {
                 links = response.headers.link.split(',');
             }
-            for(const i in links) {
+            for (const i in links) {
                 if (links[i].includes('rel="next"')) {
                     nextPage = true;
                 }
                 
             }
-
             let range = '';
-            if(response.headers['content-range']) {
+            if (response.headers['content-range']) {
                 range = response.headers['content-range'].split('-')[1]; 
             }
-            dispatch({type: types.RECEIVED_RUNS, runs: response.data, nextPage: nextPage, range: range});
+            dispatch({ type: types.RECEIVED_RUNS, runs: response.data, nextPage, range });
         }).catch((error) => {
-            dispatch({type: types.FETCH_RUNS_ERROR, error: error});
+            if (axios.isCancel(error)) {
+                console.log(error.message);
+            } else {
+                dispatch({ type: types.FETCH_RUNS_ERROR, error: error.response.data });
+            }
         });
-        
-    }
-    thunk.meta = {
-        debounce: {
-            time: 1000,
-            key: 'FETCH_RUNS'
-        }
-    }
-    return thunk;
+    };
 }
 
 export function deleteRuns(uid) {
     return (dispatch, getState) => {
-
-        dispatch({type: types.DELETING_RUN});
+        dispatch({ type: types.DELETING_RUN });
 
         const csrftoken = cookie.load('csrftoken');
 
@@ -57,16 +64,16 @@ export function deleteRuns(uid) {
         form_data.append('csrfmiddlewaretoken', csrftoken);
 
         return axios({
-            url: '/api/runs/' + uid,
+            url: `/api/runs/${uid}`,
             method: 'DELETE',
             data: form_data,
-            headers: {"X-CSRFToken": csrftoken}
-        }).then((response) => {
-            dispatch({type: types.DELETED_RUN});
-        }).catch(error => {
-            dispatch({type: types.DELETE_RUN_ERROR, error: error});
+            headers: { 'X-CSRFToken': csrftoken },
+        }).then(() => {
+            dispatch({ type: types.DELETED_RUN });
+        }).catch((error) => {
+            dispatch({ type: types.DELETE_RUN_ERROR, error: error.response.data });
         });
-    }
+    };
 }
 
 export function setPageOrder(order) {

--- a/eventkit_cloud/ui/static/ui/app/reducers/DataPackPageReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/DataPackPageReducer.js
@@ -4,15 +4,15 @@ import initialState from './initialState';
 export function DataPackPageReducer(state = initialState.runsList, action) {
     switch(action.type) {
         case types.FETCHING_RUNS:
-            return {...state, fetching: true, fetched: false, error: null}
+            return { ...state, fetching: true, fetched: false, error: null, cancelSource: action.cancelSource };
         case types.RECEIVED_RUNS:
-            return {...state, fetching: false, fetched: true, runs: action.runs, error: null, nextPage: action.nextPage, range: action.range}
+            return { ...state, fetching: false, fetched: true, runs: action.runs, error: null, nextPage: action.nextPage, range: action.range, cancelSource: null };
         case types.FETCH_RUNS_ERROR:
-            return {...state, fetching: false, fetched: false, runs: [], error: action.error};
+            return { ...state, fetching: false, fetched: false, runs: [], error: action.error, cancelSource: null };
         case types.SET_PAGE_ORDER:
-            return {...state, order: action.order}
+            return { ...state, order: action.order };
         case types.SET_PAGE_VIEW:
-            return {...state, view: action.view}
+            return { ...state, view: action.view };
         default:
             return state;
     }

--- a/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
@@ -33,6 +33,7 @@ export default {
         range: '',
         order: '',
         view: '',
+        cancelSource: null,
     },
     runsDeletion: {
         deleting: false,

--- a/eventkit_cloud/ui/static/ui/app/tests/reducers/DataPackPageReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/reducers/DataPackPageReducer.spec.js
@@ -12,6 +12,7 @@ describe('DataPackList reducer', () => {
                 range: '',
                 order: '',
                 view: '',
+                cancelSource: null,
             }
         );
     });
@@ -27,9 +28,11 @@ describe('DataPackList reducer', () => {
                 range: '',
                 order: '',
                 view: '',
+                cancelSource: null,
             },
             {
-                type: 'FETCHING_RUNS'
+                type: 'FETCHING_RUNS',
+                cancelSource: 'test',
             }
         )).toEqual(
             {
@@ -41,6 +44,7 @@ describe('DataPackList reducer', () => {
                 range: '',
                 order: '',
                 view: '',
+                cancelSource: 'test',
             }
         );
     });
@@ -56,6 +60,7 @@ describe('DataPackList reducer', () => {
                 range: '',
                 order: '',
                 view: '',
+                cancelSource: 'test',
             },
             {
                 type: 'RECEIVED_RUNS', runs: [{thisIs: 'a fake run'}], nextPage: true, range: '12/24'
@@ -70,6 +75,7 @@ describe('DataPackList reducer', () => {
                 range: '12/24',
                 order: '',
                 view: '',
+                cancelSource: null,
             }
         );
     });
@@ -85,6 +91,7 @@ describe('DataPackList reducer', () => {
                 range: '',
                 order: '',
                 view: '',
+                cancelSource: 'test',
             },
             {
                 type: 'FETCH_RUNS_ERROR', error: 'This is an error message'
@@ -99,6 +106,7 @@ describe('DataPackList reducer', () => {
                 range: '',
                 order: '',
                 view: '',
+                cancelSource: null,
             }
         );
     });


### PR DESCRIPTION
This pr fixes an async bug with the run requests.
Previously, the requests were being debounced, which was mostly effective. (60% of the time it worked every time). 
However that approach still allowed for occasional weird results in the map when filtering, so now a better approach should fix that. Instead of debouncing the request we check if one is in progress and cancel it before creating a new request.