### PR TITLE
allow '.' in username

### DIFF
--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -934,6 +934,7 @@ class UserDataViewSet(viewsets.GenericViewSet):
     parser_classes = (JSONParser,)
     filter_backends = (filters.DjangoFilterBackend, filters.SearchFilter)
     lookup_field = 'username'
+    lookup_value_regex = '[^/]+'
     search_fields = ('user__username', 'accepted_licenses')
 
     def get_queryset(self):


### PR DESCRIPTION
By default the users lookup has a regex of `'[^/.]+'` which does not allow for lookups of usernames with `.` in them. By setting `lookup_value_regex` to `'[^/]+'` we can allow for `.`
This does have the potential to interfere with the `.<format>` options if we add single username GET in the future. Example: `/api/user/admin.json` may or may not work. However it is currently not an issue since we do not allow GET request to an individual user like `/api/user/admin`