### PR TITLE
show error and disable rerun for non-owners

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/actions/statusDownloadActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/statusDownloadActions.js
@@ -67,9 +67,8 @@ export const rerunExport = jobuid => (dispatch) => {
             },
         });
     }).catch((error) => {
-        console.log(error);
         dispatch({
-            type: types.RERUN_EXPORT_ERROR, error,
+            type: types.RERUN_EXPORT_ERROR, error: error.response.data,
         });
     });
 };

--- a/eventkit_cloud/ui/static/ui/app/components/BaseDialog.js
+++ b/eventkit_cloud/ui/static/ui/app/components/BaseDialog.js
@@ -19,7 +19,6 @@ export class BaseDialog extends Component {
                 padding: '25px',
                 fontWeight: 'none',
                 fontSize: '18px',
-                color: 'grey',
                 ...this.props.titleStyle,
             },
             body: {

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
@@ -473,7 +473,9 @@ export class DataCartDetails extends Component {
                         <RaisedButton
                             className="qa-DataCartDetails-RaistedButton-rerunExport"
                             style={{ margin: '10px' }}
-                            disabled={this.state.status === 'SUBMITTED'}
+                            disabled={
+                                this.state.status === 'SUBMITTED' || this.props.user.data.user.username !== this.props.cartDetails.user
+                            }
                             backgroundColor="rgba(226,226,226,0.5)"
                             disableTouchRipple
                             labelColor="#4598bf"
@@ -674,6 +676,7 @@ DataCartDetails.propTypes = {
     maxResetExpirationDays: PropTypes.string.isRequired,
     providers: PropTypes.array.isRequired,
     zipFileProp: PropTypes.string,
+    user: PropTypes.object.isRequired,
 };
 
 export default DataCartDetails;

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartDetails.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartDetails.spec.js
@@ -35,6 +35,7 @@ describe('DataCartDetails component', () => {
             onRunRerun: () => {},
             onClone: () => {},
             onProviderCancel: () => {},
+            user: { data: { user: { username: 'admin' } } },
         }
     );
 

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/StatusDownload.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/StatusDownload.spec.js
@@ -253,6 +253,13 @@ describe('StatusDownload component', () => {
                 error: null,
             },
             providers:providers,
+            user: {
+                data: {
+                    user: {
+                        username: 'admin'
+                    },
+                },
+            },
             getDatacartDetails: (jobuid) => {},
             deleteRun: (jobuid) => {},
             rerunExport: (jobuid) => {},
@@ -405,8 +412,8 @@ describe('StatusDownload component', () => {
         expect(stateSpy.calledWith({isLoading: false})).toBe(true);
         expect(clearSpy.calledOnce).toBe(true);
         expect(clearSpy.calledWith(wrapper.instance().timer)).toBe(true);
-        expect(setTimeout.mock.calls.length).toBe(12);
-        expect(setTimeout.mock.calls[3][1]).toBe(270000);
+        expect(setTimeout.mock.calls.length).toBe(13);
+        expect(setTimeout.mock.calls[4][1]).toBe(270000);
         stateSpy.restore();
         propsSpy.restore();
         clearSpy.restore();
@@ -429,7 +436,7 @@ describe('StatusDownload component', () => {
         expect(stateSpy.calledWith({datacartDetails: exampleRunTaskRunning, zipFileProp:"http://cloud.eventkit.dev/downloads/6870234f-d876-467c-a332-65fdf0399a0d/TestGPKG-WMTS-TestProject-eventkit-20170310.zip"})).toBe(true);
         expect(clearSpy.calledOnce).toBe(false);
         expect(clearSpy.calledWith(wrapper.instance().timer)).toBe(false);
-        expect(setTimeout.mock.calls.length).toBe(11);
+        expect(setTimeout.mock.calls.length).toBe(12);
         expect(setTimeout.mock.calls[3][1]).toBe(0);
         StatusDownload.prototype.setState.restore();
         StatusDownload.prototype.componentWillReceiveProps.restore();
@@ -491,4 +498,40 @@ describe('StatusDownload component', () => {
         updateSpy.restore();
     });
 
+    it('should set error state on export rerun error', () => {
+        const props = getProps();
+        const stateSpy = sinon.spy(StatusDownload.prototype, 'setState');
+        const wrapper = getWrapper(props);
+        const nextProps = getProps();
+        const error = [{ detail: 'this is an error' }];
+        nextProps.exportReRun.error = error;
+        wrapper.setProps(nextProps);
+        expect(stateSpy.calledWith({ error })).toBe(true);
+        stateSpy.restore();
+    });
+
+    it('getErrorMessage should return null if no error in state', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        expect(wrapper.state().error).toBe(null);
+        expect(wrapper.instance().getErrorMessage()).toBe(null);
+    });
+
+    it('getErrorMessage should return an array of error messages', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        const error = [{ detail: 'one' }, { detail: 'two' }];
+        wrapper.setState({ error });
+        const ret = wrapper.instance().getErrorMessage();
+        expect(ret).toHaveLength(2);
+    });
+
+    it('clearError should set error state to null', () => {
+        const props = getProps();
+        const stateSpy = sinon.spy(StatusDownload.prototype, 'setState');
+        const wrapper = getWrapper(props);
+        wrapper.instance().clearError();
+        expect(stateSpy.calledWith({ error: null })).toBe(true);
+        stateSpy.restore();
+    });
 });


### PR DESCRIPTION
This pr adds an error message for rerun failure. It also disables the rerun button for users who do not own the DataPack.
![image](https://user-images.githubusercontent.com/16799449/34175948-348f2b76-e4cc-11e7-8c34-a88124f69e79.png)
(this particular error message should not show since the button is disabled for non-owners)