### PR TITLE
add scaleline to datapack page

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGridItem.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackGridItem.js
@@ -23,6 +23,7 @@ import VectorLayer from 'ol/layer/vector';
 import Tile from 'ol/layer/tile';
 import Attribution from 'ol/control/attribution';
 import Zoom from 'ol/control/zoom';
+import ScaleLine from 'ol/control/scaleline';
 
 import BaseDialog from '../BaseDialog';
 import DeleteDialog from '../DeleteDialog';
@@ -87,6 +88,9 @@ export class DataPackGridItem extends Component {
                 }),
                 new Zoom({
                     className: [ol3mapCss.olZoom, ol3mapCss.olControlTopLeft].join(' '),
+                }),
+                new ScaleLine({
+                    className: ol3mapCss.olScaleLine,
                 }),
             ],
         });

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -25,6 +25,7 @@ import GeoJSON from 'ol/format/geojson';
 import VectorLayer from 'ol/layer/vector';
 import Tile from 'ol/layer/tile';
 import Attribution from 'ol/control/attribution';
+import ScaleLine from 'ol/control/scaleline';
 import Zoom from 'ol/control/zoom';
 import ZoomToExtent from 'ol/control/zoomtoextent';
 import OverviewMap from 'ol/control/overviewmap';
@@ -235,6 +236,9 @@ export class MapView extends Component {
         icon.className = 'fa fa-globe';
         return new Map({
             controls: [
+                new ScaleLine({
+                    className: css.olScaleLine,
+                }),
                 new Attribution({
                     className: ['ol-attribution', css['ol-attribution']].join(' '),
                     collapsible: false,
@@ -257,8 +261,7 @@ export class MapView extends Component {
                     className: ['ol-overviewmap', css['ol-custom-overviewmap']].join(' '),
                     collapsible: true,
                     collapsed: window.innerWidth < 768,
-                    collapseLabel: '\u00BB',
-                    label: '\u00AB',
+                    tipLabel: '',
                 }),
             ],
             interactions: interaction.defaults({

--- a/eventkit_cloud/ui/static/ui/app/styles/ol3map.css
+++ b/eventkit_cloud/ui/static/ui/app/styles/ol3map.css
@@ -133,10 +133,20 @@ div.map {
     content: "✖";
 }
 
+.ol-custom-overviewmap:not(.ol-collapsed) {
+    left: 10px;
+    right: initial;
+    bottom: 25px;
+}
+
 .ol-custom-overviewmap:not(.ol-collapsed) > div {
     border: none;
     width: 100px;
     height: 100px;
+}
+
+.ol-custom-overviewmap:not(.ol-collapsed) button {
+    left: 2px;
 }
 
 .ol-attribution > ul > li {


### PR DESCRIPTION
This PR adds a scale line to the DataPack page map-view and grid-items. On the map-view the mini-map has been moved to the left to accommodate for the scale line.
![image](https://user-images.githubusercontent.com/16799449/34259006-84d16a32-e62e-11e7-8b0c-89f53dec1857.png)
![image](https://user-images.githubusercontent.com/16799449/34259017-927cb560-e62e-11e7-8487-1e9a94c2157c.png)
