### PR TITLE
dont filter the query results in the ui

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/MapTools/SearchAOIToolbar.js
+++ b/eventkit_cloud/ui/static/ui/app/components/MapTools/SearchAOIToolbar.js
@@ -112,6 +112,11 @@ export class SearchAOIToolbar extends Component {
                         placeholder={'Search admin boundary or location...'}
                         onInputChange={this.handleInputChange}
                         labelKey={'name'}
+                        filterBy={() => (
+                            // this disables the built in filtering
+                            // we dont need it since we are getting results dynamically based on input
+                            true
+                        )}
                         paginate={false}
                         emptyLabel={''}
                         minLength={2}


### PR DESCRIPTION
This fixes the issue with no results showing when a search query includes extra spaces.
The typeahead component filters results by default, making sure they match the input string. We do not need this functionality since our results are coming from a search on the backend.