### PR TITLE
add eslint as an install option

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+    "extends": "airbnb",
+    "env": {
+        "browser": true,
+        "node": true,
+        "jest": true
+    },
+    "rules": {
+        "class-methods-use-this": "off",
+        "no-console": "off",
+        "import/no-named-as-default": "off",
+        "import/prefer-default-export": "off",
+        "indent": [2, 4],
+        "linebreak-style": ["error", "windows"],
+
+        "react/jsx-filename-extension": 0,
+        "react/jsx-indent": [2, 4],
+        "react/jsx-indent-props": [2, 4],
+        "react/prefer-stateless-function": "off",
+		"react/forbid-prop-types": ["error", { "forbid": ["any", "array"] }]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ staticfiles/
 node_modules/
 .DS_Store
 .flowconfig
-.eslintrc.json
-
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/config/Dockerfile_webpack
+++ b/config/Dockerfile_webpack
@@ -7,7 +7,7 @@ COPY ./config/setupFile.js /var/lib/eventkit/
 COPY ./nightwatch.json /var/lib/eventkit/
 RUN apt-get update && apt-get install -y ruby git libcairo2-dev libjpeg62-turbo-dev libpango1.0-dev libgif-dev build-essential g++
 RUN npm install npm@4.0.2 --quiet
-RUN npm install --quiet
+RUN npm install --no-optional --quiet
 #RUN npm install webpack webpack-dev-server -g --quiet
 RUN gem install coveralls-lcov
 

--- a/config/Dockerfile_webpack
+++ b/config/Dockerfile_webpack
@@ -7,7 +7,7 @@ COPY ./config/setupFile.js /var/lib/eventkit/
 COPY ./nightwatch.json /var/lib/eventkit/
 RUN apt-get update && apt-get install -y ruby git libcairo2-dev libjpeg62-turbo-dev libpango1.0-dev libgif-dev build-essential g++
 RUN npm install npm@4.0.2 --quiet
-RUN npm install --no-optional --quiet
+RUN npm install --quiet
 #RUN npm install webpack webpack-dev-server -g --quiet
 RUN gem install coveralls-lcov
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,13 @@
     "webpack-dev-server": "~2.4.5",
     "write-file-webpack-plugin": "~4.0.2"
   },
+  "optionalDependencies": {
+    "eslint": "4.9.0",
+    "eslint-plugin-import": "2.7.0",
+    "eslint-plugin-react": "7.4.0",
+    "eslint-plugin-jsx-a11y": "6.0.2",
+    "eslint-config-airbnb": "16.1.0"
+  },
   "babel": {
     "plugins": [
       "react-hot-loader/babel",
@@ -118,7 +125,8 @@
     "start": "node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline",
     "coverage": "node_modules/jest-cli/bin/jest.js --coverage --silent && mkdir -p /var/lib/eventkit/coverage/coveralls && coveralls-lcov -v -n /var/lib/eventkit/coverage/lcov.info > /var/lib/eventkit/coverage/coveralls/coveralls.json",
     "test": "node_modules/jest-cli/bin/jest.js --silent",
-    "e2e": "node_modules/nightwatch/bin/nightwatch"
+    "e2e": "node_modules/nightwatch/bin/nightwatch",
+    "install-linter": "npm install eslint@4.9.0 eslint-plugin-import@2.7.0 eslint-plugin-react@7.4.0 eslint-plugin-jsx-a11y@6.0.2 eslint-config-airbnb@16.1.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -71,13 +71,6 @@
     "webpack-dev-server": "~2.4.5",
     "write-file-webpack-plugin": "~4.0.2"
   },
-  "optionalDependencies": {
-    "eslint": "4.9.0",
-    "eslint-plugin-import": "2.7.0",
-    "eslint-plugin-react": "7.4.0",
-    "eslint-plugin-jsx-a11y": "6.0.2",
-    "eslint-config-airbnb": "16.1.0"
-  },
   "babel": {
     "plugins": [
       "react-hot-loader/babel",

--- a/readme.md
+++ b/readme.md
@@ -103,8 +103,7 @@ By default, the Eventkit webpack is configured for development, if you need to c
 To use ESLint while working on the EventKit front-end, first make sure you have Node.js and NPM installed in your local dev environment.
 You can find the instructions for installing them here https://docs.npmjs.com/getting-started/installing-node
 Then in the EventKit root directory (on your local machine, not in the docker container) simply run:
-<pre>npm run-script install-linter</pre> if you only want the linting packages installed.
-Or <pre>npm install</pre> if you want all EventKit npm packages installed along with the linting packages (*Please note installing all packages will take some time and if you are running windows some packages may fail to install*).
+<pre>npm run-script install-linter</pre>
 
 Next you will need to follow instructions to add ESLint into your IDE of choice.
 For most IDEs that should mean finding and installing (if not already installed) the relevant ESLint plugin, and if needed, adjusting the settings to point to your specific package install location.

--- a/readme.md
+++ b/readme.md
@@ -96,3 +96,23 @@ EXPORT_DOWNLOAD_ROOT='/path/to/download/dir/'</pre>
 ## Building the bundle
 By default, the Eventkit webpack is configured for development, if you need to create bundle and vendor files for production run
 <pre>docker-compose run --rm webpack npm run build</pre>
+
+
+## For Developers
+#### Using ESLint
+To use ESLint while working on the EventKit front-end, first make sure you have Node.js and NPM installed in your local dev environment.
+You can find the instructions for installing them here https://docs.npmjs.com/getting-started/installing-node
+Then in the EventKit root directory (on your local machine, not in the docker container) simply run:
+<pre>npm run-script install-linter</pre> if you only want the linting packages installed.
+Or <pre>npm install</pre> if you want all EventKit npm packages installed along with the linting packages (*Please note installing all packages will take some time and if you are running windows some packages may fail to install*).
+
+Next you will need to follow instructions to add ESLint into your IDE of choice.
+For most IDEs that should mean finding and installing (if not already installed) the relevant ESLint plugin, and if needed, adjusting the settings to point to your specific package install location.
+
+For VSCode try the following:
+https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+
+For WebStorm try the following:
+https://www.jetbrains.com/help/webstorm/eslint.html
+
+Finally, if you would like to adjust any of the linting rules edit the .eslintrc.json file in the EventKit root directory.


### PR DESCRIPTION
This PR adds in the ESLint packages require for using the AirBnB ESLint config.
We can modify the rules using our own .eslintrc.json file.
Install the linting packages using  `npm run-script install-linter`.
