### PR TITLE
Fix create datapack warning

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/CreateExport.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/CreateExport.js
@@ -21,7 +21,7 @@ export class CreateExport extends React.Component {
         // Show warning dialog if we try to navigate away with changes.
         const route = this.props.routes[this.props.routes.length - 1];
         this.props.router.setRouteLeaveHook(route, (info) => {
-            if (!this.state.modified || this.leaveRoute) {
+            if (!this.state.modified || this.leaveRoute || info.pathname.indexOf('/status') === 0) {
                 // No changes to lose, or we confirmed we want to leave.
                 return true;
             }

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/CreateExport.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/CreateExport.js
@@ -10,6 +10,7 @@ export class CreateExport extends React.Component {
 
     constructor(props) {
         super(props);
+        this.routeLeaveHook = this.routeLeaveHook.bind(this);
         this.state = {
             showLeaveWarningDialog: false,
             modified: false,
@@ -18,19 +19,8 @@ export class CreateExport extends React.Component {
     }
 
     componentDidMount() {
-        // Show warning dialog if we try to navigate away with changes.
         const route = this.props.routes[this.props.routes.length - 1];
-        this.props.router.setRouteLeaveHook(route, (info) => {
-            if (!this.state.modified || this.leaveRoute || info.pathname.indexOf('/status') === 0) {
-                // No changes to lose, or we confirmed we want to leave.
-                return true;
-            }
-
-            // We must have started making changes. Save the route we're trying to navigate to and show a warning.
-            this.leaveRoute = info.pathname;
-            this.setState({ showLeaveWarningDialog: true });
-            return false;
-        });
+        this.props.router.setRouteLeaveHook(route, this.routeLeaveHook);
     }
 
     componentWillReceiveProps(nextProps) {
@@ -38,6 +28,19 @@ export class CreateExport extends React.Component {
             !isEqual(nextProps.exportInfo, this.props.exportInfo)) {
             this.setState({ modified: true });
         }
+    }
+
+    routeLeaveHook(info) {
+        // Show warning dialog if we try to navigate away with changes.
+        if (!this.state.modified || this.leaveRoute || info.pathname.indexOf('/status') === 0) {
+            // No changes to lose, or we confirmed we want to leave.
+            return true;
+        }
+
+        // We must have started making changes. Save the route we're trying to navigate to and show a warning.
+        this.leaveRoute = info.pathname;
+        this.setState({ showLeaveWarningDialog: true });
+        return false;
     }
 
     handleLeaveWarningDialogCancel = () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/CreateExport.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/CreateExport.spec.js
@@ -64,6 +64,24 @@ describe('CreateExport component', () => {
         expect(wrapper.state().modified).toBe(true);
     });
 
+    it('should set leave route and show leave warning dialog when navigating away with changes', () => {
+        const wrapper = getShallowWrapper();
+        const instance = wrapper.instance();
+        wrapper.setState({ modified: true });
+        instance.routeLeaveHook({ pathname: '/someRoute' });
+        expect(instance.leaveRoute).toBe('/someRoute');
+        expect(wrapper.state().showLeaveWarningDialog).toBe(true);
+    });
+
+    it('should not show leave warning dialog when finishing new datapack', () => {
+        const wrapper = getShallowWrapper();
+        const instance = wrapper.instance();
+        wrapper.setState({ modified: true });
+        expect(instance.routeLeaveHook({ pathname: '/status/12345' })).toBe(true);
+        expect(instance.leaveRoute).toBe(null);
+        expect(wrapper.state().showLeaveWarningDialog).toBe(false);
+    });
+
     it('should hide leave warning dialog when clicking cancel', () => {
         const wrapper = getShallowWrapper();
         const instance = wrapper.instance();
@@ -81,6 +99,6 @@ describe('CreateExport component', () => {
         instance.leaveRoute = '/someRoute';
         instance.handleLeaveWarningDialogConfirm();
         expect(instance.props.router.push.calledOnce).toBe(true);
-        expect(instance.props.router.push.getCall(0).args[0]).toEqual('/someRoute');
+        expect(instance.props.router.push.getCall(0).args[0]).toBe('/someRoute');
     });
 });


### PR DESCRIPTION
To reproduce the bug, go through the standard process of creating a datapack. When you click the green checkmark button to finish, the destructive action warning is incorrectly displayed. With this fix it should only be displayed when navigating away without finishing the new datapack. 

![selection_033](https://user-images.githubusercontent.com/3220897/37003473-f86d49ec-2081-11e8-9923-9d0bbda4fad5.png)

