### PR TITLE
Status download fixes

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -400,11 +400,12 @@ export class ExportInfo extends React.Component {
             },
             listHeading: {
                 height: '20px',
-                fontSize: '13px',
+                fontSize: '16px',
+                fontWeight: 300,
             },
             providerListHeading: {
                 position: 'absolute',
-                marginLeft: '50px',
+                marginLeft: '10px',
             },
             refreshIcon: {
                 marginBottom: '-4px',
@@ -507,11 +508,12 @@ export class ExportInfo extends React.Component {
                             <div style={style.sectionBottom}>
                                 <div className="qa-ExportInfo-ListHeader" style={style.listHeading}>
                                     <span className="qa-ExportInfo-ListHeaderItem"
-                                    style={style.providerListHeading}>
+                                        style={style.providerListHeading}
+                                    >
                                         DATA PROVIDERS
                                     </span>
                                     <span className="qa-ExportInfo-ListHeaderItem"
-                                    style={{ position: 'absolute', left: '60%' }}
+                                        style={{ marginLeft: '75%' }}
                                     >
                                         AVAILABILITY
                                         <NavigationRefresh

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
@@ -126,7 +126,7 @@ export class DataCartGeneralTable extends Component {
                                 >
                                     <div style={{ paddingBottom: '20px', wordWrap: 'break-word' }}>
                                         EventKit provides all geospatial data in the GeoPackage (.gpkg) format.
-                                            Additional format support will be added in subsequent versions.
+                                        Additional format support will be added in subsequent versions.
                                     </div>
                                 </BaseDialog>
                             </div>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
@@ -55,13 +55,14 @@ export class DataCartGeneralTable extends Component {
 
         const styles = {
             tableRowInfoIcon: {
-                marginLeft: '10px',
+                marginLeft: '5px',
                 height: '18px',
                 width: '18px',
                 cursor: 'pointer',
                 display: 'inlineBlock',
                 fill: '#4598bf',
                 verticalAlign: 'middle',
+                marginRight: '10px',
             },
         };
 


### PR DESCRIPTION
This branch updates a few UI issues.  
1. on the status and download page the info icons were smooshed up against the next data source name.  Added a margin to the right and took down the margin to the left to show which source the icon belongs to. This fix also applies to the File Formats and the Projection data.  In the future if there are more than one formats or projects, margins are fixed.
Before:
![image](https://user-images.githubusercontent.com/16208809/37720654-1ca97a50-2cfe-11e8-89e9-36398270fc46.png)

After:
![image](https://user-images.githubusercontent.com/16208809/37720666-23d73f60-2cfe-11e8-93c5-ddb72a9af503.png)


2. On the Export Info page, the headings for Data Providers and Availability were a bit misaligned.  Fixed alignment, upped the font size and weight.
Before:
![image](https://user-images.githubusercontent.com/16208809/37720693-2c64ce68-2cfe-11e8-99c3-392f0710a86e.png)


After:
![image](https://user-images.githubusercontent.com/16208809/37720709-3390d754-2cfe-11e8-97c8-a1f8cbad058b.png)

