### PR TITLE
Support client certs via MapProxy

### DIFF
--- a/eventkit_cloud/jobs/admin.py
+++ b/eventkit_cloud/jobs/admin.py
@@ -138,11 +138,11 @@ class DataProviderForm(forms.ModelForm):
             if not config:
                 return
             from ..utils.external_service import ExternalRasterServiceToGeopackage, \
-                                                 ConfigurationError, SeedConfigurationError
+                                                 ConfigurationError
             service = ExternalRasterServiceToGeopackage(layer=self.cleaned_data.get('layer'), service_type=self.cleaned_data.get('export_provider_type'), config=config)
             try:
                 conf_dict, seed_configuration, mapproxy_configuration = service.get_check_config()
-            except (ConfigurationError, SeedConfigurationError) as e:
+            except ConfigurationError as e:
                 raise forms.ValidationError(e.message)
 
         elif service_type in ['osm', 'osm-generic']:

--- a/eventkit_cloud/utils/auth_requests.py
+++ b/eventkit_cloud/utils/auth_requests.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
+import re
 import httplib
-import requests
 from tempfile import NamedTemporaryFile
-
 import logging
+from functools import wraps
+import requests
+
 
 logger = logging.getLogger(__name__)
 
@@ -15,19 +17,20 @@ def content_to_file(content):
     passing it to the decorated function as the keyword argument `cert`.
     """
     def decorator(func):
+        @wraps(func)
         def wrapper(*args, **kwargs):
             if content:
-                logger.debug("Content found for {}({}, {})".format(func.__name__,
-                                                                   ", ".join([str(arg) for arg in args]),
-                                                                   ", ".join(["{}={}".format(k, v) for k, v
-                                                                              in kwargs.iteritems()])))
+                logger.debug("Content found for %s(%s, %s)",
+                             func.__name__,
+                             ", ".join([str(arg) for arg in args]),
+                             ", ".join(["%s=%s" % (k, v) for k, v in kwargs.iteritems()]))
                 with NamedTemporaryFile() as certfile:
                     certfile.write(content)
                     certfile.flush()
                     return func(cert=certfile.name, *args, **kwargs)
             else:
                 return func(*args, **kwargs)
-        logger.debug("Cert wrapped function {}".format(func.__name__))
+        logger.debug("Cert wrapped function %s", func.__name__)
         return wrapper
     return decorator
 
@@ -55,7 +58,9 @@ def slug_to_cert(func):
     Decorator that takes a kwarg `slug` of the target function, and replaces it with `cert`, which points to an
     open file containing the client certificate and key for that provider slug.
     If an environment variable for that slug and cert was not found, call the function without the cert kwarg.
+    To avoid unnecessary overhead in creating multiple temporary files, this decorator should generally be applied last.
     """
+    @wraps(func)
     def wrapper(*args, **kwargs):
         cert_env = find_cert(kwargs.pop("slug", None))
 
@@ -63,7 +68,44 @@ def slug_to_cert(func):
     return wrapper
 
 
+def handle_basic_auth(func):
+    """
+    Decorator for requests methods that retries 401 response codes using username and password from query string
+     to construct a HTTPBasicAuth.
+    :param func: A requests method that returns an instance of requests.models.Response
+    :return: result of initial call if successful, or result of retry if it was 401 and username/password were available
+    """
+    @wraps(func)
+    def wrapper(url, **kwargs):
+        response = func(url, **kwargs)
+        if not isinstance(response, requests.models.Response):
+            return response
+        if response.status_code != 401:
+            return response
+        # We're unauthorized; look for username/password
+        # Check kwargs
+        params = kwargs.get("params")
+        cred = None
+        if params and params.get("username") and params.get("password"):
+            cred = (params.get("username"), params.get("password"))
+
+        if not cred:
+            # Check query string
+            username = re.search(r"(?<=[?&]username=)[a-zA-Z0-9\-._~]+", url)
+            password = re.search(r"(?<=[?&]password=)[a-zA-Z0-9\-._~]+", url)
+            cred = (username.group(), password.group()) if username and password else None
+
+        if not cred:
+            return response
+
+        kwargs["auth"] = cred
+        response = func(url, **kwargs)
+        return response
+    return wrapper
+
+
 @slug_to_cert
+@handle_basic_auth
 def get(url, **kwargs):
     """
     As requests.get, but replaces the "slug" kwarg with "cert", pointing to a temporary file holding cert and key info,
@@ -76,6 +118,7 @@ def get(url, **kwargs):
 
 
 @slug_to_cert
+@handle_basic_auth
 def post(url, **kwargs):
     """
     As requests.post, but replaces the "slug" kwarg with "cert", pointing to a temporary file holding cert and key info,
@@ -99,14 +142,14 @@ def patch_https(slug):
     :return: None
     """
     cert = find_cert(slug)
-    logger.debug("Patching with slug {}, cert [{} B]".format(slug, len(cert) if cert is not None else 0))
+    logger.debug("Patching with slug %s, cert [%s B]", slug, len(cert) if cert is not None else 0)
 
     @content_to_file(cert)
     def _new_init(_self, *args, **kwargs):
         certfile = kwargs.pop("cert", None)
         kwargs["key_file"] = certfile or kwargs.get("key_file", None)
         kwargs["cert_file"] = certfile or kwargs.get("cert_file", None)
-        logger.debug("Initializing new HTTPSConnection with provider={}, certfile={}".format(slug, certfile))
+        logger.debug("Initializing new HTTPSConnection with provider=%s, certfile=%s", slug, certfile)
         _ORIG_HTTPSCONNECTION_INIT(_self, *args, **kwargs)
 
     httplib.HTTPSConnection.__init__ = _new_init

--- a/eventkit_cloud/utils/auth_requests.py
+++ b/eventkit_cloud/utils/auth_requests.py
@@ -4,35 +4,85 @@ import requests
 import os
 from tempfile import NamedTemporaryFile
 
+import httplib
+
 logger = logging.getLogger(__name__)
 
 
-def with_cert(method, url, slug=None, **kwargs):
-    try:
-        if slug:
-            cert_env = os.getenv(slug + "_CERT") or os.getenv(slug.upper() + "_CERT")
-        else:
-            cert_env = None
+def content_to_file(content):
+    """
+    Given content for a file, constructs a decorator that creates and destroys a temporary file containing that content,
+    passing it to the decorated function as the keyword argument `cert`.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            if content:
+                logger.debug("Certfile found for {}({}, {})".format(func.__name__,
+                                                                   ", ".join([str(arg) for arg in args]),
+                                                                   ", ".join(["{}={}".format(k, v) for k, v in kwargs.iteritems()])))
+                with NamedTemporaryFile() as certfile:
+                    certfile.write(content)
+                    certfile.flush()
+                    return func(cert=certfile.name, *args, **kwargs)
+            else:
+                return func(*args, **kwargs)
+        logger.debug("Cert wrapped function {}".format(func.__name__))
+        return wrapper
+    return decorator
 
-        if slug and cert_env:
-            logger.info("Requesting {} with cert for {}".format(url, slug))
-            with NamedTemporaryFile() as f:
-                f.write(cert_env)
-                f.flush()
-                response = method(url, cert=f.name, **kwargs)
-                logger.info("Response: [{}], {} B".format(response.status_code, len(response.text)))
-            return response
-        else:
-            response = method(url, **kwargs)
-            return response
+
+def find_cert(slug=None):
+    if slug:
+        cert = os.getenv(slug + "_CERT") or os.getenv(slug.upper() + "_CERT")
+    else:
+        cert = None
+    return cert
+
+
+def slug_to_cert(func):
+    """
+    Decorator that takes a kwarg `slug` of the target function, and replaces it with `cert`, which points to an
+    open file containing the client certificate and key for that provider slug.
+    If an environment variable for that slug and cert was not found, call the function without the cert kwarg.
+    """
+    def wrapper(*args, **kwargs):
+        cert_env = find_cert(kwargs.pop("slug", None))
+
+        return content_to_file(cert_env)(func)(*args, **kwargs)
+    return wrapper
+
+
+@slug_to_cert
+def request_with_cert(method, url, **kwargs):
+    try:
+        return method(url, **kwargs)
     except requests.exceptions.SSLError as e:
         logger.error('Could not establish SSL connection: possibly missing client certificate')
-        raise requests.exceptions.SSLError(e)
+        raise e
 
 
 def get(url, **kwargs):
-    return with_cert(requests.get, url, **kwargs)
+    return request_with_cert(requests.get, url, **kwargs)
 
 
 def post(url, **kwargs):
-    return with_cert(requests.post, url, **kwargs)
+    return request_with_cert(requests.post, url, **kwargs)
+
+
+_orig_HTTPSConnection_init = httplib.HTTPSConnection.__init__
+
+
+def patch_https(slug):
+    cert = find_cert(slug)
+
+    @content_to_file(cert)
+    def _new_init(_self, *args, **kwargs):
+        certfile = kwargs.pop("cert", None)
+        kwargs["key_file"] = certfile
+        kwargs["cert_file"] = certfile
+        logger.debug("Initializing new HTTPSConnection with certfile={}".format(certfile))
+        _orig_HTTPSConnection_init(_self, *args, **kwargs)
+
+    httplib.HTTPSConnection.__init__ = _new_init
+
+patch_https(None)

--- a/eventkit_cloud/utils/external_service.py
+++ b/eventkit_cloud/utils/external_service.py
@@ -157,6 +157,7 @@ class ExternalRasterServiceToGeopackage(object):
         logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:
             auth_requests.patch_https(self.name)
+            auth_requests.patch_mapproxy_opener_cache()
             check_service(conf_dict, self.name)
             progress_logger = CustomLogger(verbose=True, task_uid=self.task_uid)
             task_process = TaskProcess(task_uid=self.task_uid)

--- a/eventkit_cloud/utils/external_service.py
+++ b/eventkit_cloud/utils/external_service.py
@@ -157,7 +157,7 @@ class ExternalRasterServiceToGeopackage(object):
         logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:
             auth_requests.patch_https(self.name)
-            auth_requests.patch_mapproxy_opener_cache()
+            auth_requests.patch_mapproxy_opener_cache(slug=self.name)
             check_service(conf_dict, self.name)
             progress_logger = CustomLogger(verbose=True, task_uid=self.task_uid)
             task_process = TaskProcess(task_uid=self.task_uid)

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from django.utils.translation import ugettext as _
+from django.conf import settings
 from enum import Enum
 import json
 import logging
@@ -94,6 +95,7 @@ class ProviderCheck(object):
         self.slug = slug
         self.result = CheckResults.SUCCESS
         self.timeout = 10
+        self.verify = getattr(settings, "DISABLE_SSL_VERIFICATION", False)
 
         if aoi_geojson is not None and aoi_geojson is not "":
             if isinstance(aoi_geojson, str):
@@ -118,7 +120,8 @@ class ProviderCheck(object):
                 self.result = CheckResults.NO_URL
                 return None
 
-            response = auth_requests.get(self.service_url, slug=self.slug, params=self.query, timeout=self.timeout)
+            response = auth_requests.get(self.service_url, slug=self.slug, params=self.query, timeout=self.timeout,
+                                         verify=self.verify)
 
             self.token_dict['status'] = response.status_code
 
@@ -191,7 +194,8 @@ class OverpassProviderCheck(ProviderCheck):
                 self.result = CheckResults.NO_URL
                 return None
 
-            response = auth_requests.post(url=self.service_url, slug=self.slug, data="out meta;", timeout=self.timeout)
+            response = auth_requests.post(url=self.service_url, slug=self.slug, data="out meta;", timeout=self.timeout,
+                                          verify=self.verify)
 
             self.token_dict['status'] = response.status_code
 

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
 from django.utils.translation import ugettext as _
@@ -120,6 +121,10 @@ class ProviderCheck(object):
                 self.result = CheckResults.NO_URL
                 return None
 
+            logger.debug("Checking url %s&%s",
+                         self.service_url,
+                         '&'.join(['{}={}'.format(k, v) for k, v in self.query.iteritems()]))
+
             response = auth_requests.get(self.service_url, slug=self.slug, params=self.query, timeout=self.timeout,
                                          verify=self.verify)
 
@@ -192,7 +197,7 @@ class OverpassProviderCheck(ProviderCheck):
         try:
             if not self.service_url:
                 self.result = CheckResults.NO_URL
-                return None
+                return
 
             response = auth_requests.post(url=self.service_url, slug=self.slug, data="out meta;", timeout=self.timeout,
                                           verify=self.verify)
@@ -201,30 +206,30 @@ class OverpassProviderCheck(ProviderCheck):
 
             if response.status_code in [401, 403]:
                 self.result = CheckResults.UNAUTHORIZED
-                return None
+                return
 
             if response.status_code == 404:
                 self.result = CheckResults.NOT_FOUND
-                return None
+                return
 
             if not response.ok:
                 self.result = CheckResults.UNAVAILABLE
-                return None
+                return
 
         except requests.exceptions.ConnectTimeout as ex:
             logger.error("Provider check timed out for URL {}".format(self.service_url))
             self.result = CheckResults.TIMEOUT
-            return None
+            return
 
         except requests.exceptions.SSLError as ex:
             logger.error("Provider check failed for URL {}: {}".format(self.service_url, ex.message))
             self.result = CheckResults.SSL_EXCEPTION
-            return None
+            return
 
         except (requests.exceptions.ConnectionError, requests.exceptions.MissingSchema) as ex:
             logger.error("Provider check failed for URL {}: {}".format(self.service_url, ex.message))
             self.result = CheckResults.CONNECTION
-            return None
+            return
 
 
 class OWSProviderCheck(ProviderCheck):
@@ -243,8 +248,8 @@ class OWSProviderCheck(ProviderCheck):
         self.query = {
             "VERSION": "1.0.0",
             "REQUEST": "GetCapabilities"
-            # Amended with "SERVICE" parameter by subclasses
         }
+        # Amended with "SERVICE" parameter by subclasses
 
         # If service or version parameters are left in query string, it can lead to a protocol error and false negative
         self.service_url = re.sub(r"(?i)(version|service|request)=.*?(&|$)", "", self.service_url)
@@ -334,13 +339,13 @@ class WCSProviderCheck(OWSProviderCheck):
         # Get names of available coverages
         coverage_offers = content_meta.findall("coverageofferingbrief")
 
-        cover_names = map(lambda c: (c, c.find("name")), coverage_offers)
-        if len(cover_names) == 0:  # No coverages are offered
+        cover_names = [(c, c.find("name")) for c in coverage_offers]
+        if not cover_names:  # No coverages are offered
             self.result = CheckResults.LAYER_NOT_AVAILABLE
             return None
 
         covers = [c for c, n in cover_names if n is not None and self.layer == n.text]
-        if len(covers) == 0:  # Requested coverage is not offered
+        if not covers:  # Requested coverage is not offered
             self.result = CheckResults.LAYER_NOT_AVAILABLE
             return None
 
@@ -355,7 +360,7 @@ class WCSProviderCheck(OWSProviderCheck):
         pos = envelope.getchildren()
         # Make sure there aren't any surprises
         coord_pattern = re.compile(r"^-?\d+(\.\d+)? -?\d+(\.\d+)?$")
-        if len(pos) == 0 or not all("pos" in p.tag and re.match(coord_pattern, p.text) for p in pos):
+        if not pos or not all("pos" in p.tag and re.match(coord_pattern, p.text) for p in pos):
             return None
 
         x1, y1 = map(float, pos[0].text.split(' '))
@@ -389,11 +394,11 @@ class WFSProviderCheck(OWSProviderCheck):
         feature_types = feature_type_list.findall("featuretype")
 
         # Get layer names
-        feature_names = map(lambda f: (f, f.find("name")), feature_types)
+        feature_names = [(ft, ft.find("name")) for ft in feature_types]
         logger.debug("WFS layers offered: {}".format([n.text for f, n in feature_names if n]))
         features = [f for f, n in feature_names if n is not None and self.layer == n.text]
 
-        if len(features) == 0:
+        if not features:
             self.result = CheckResults.LAYER_NOT_AVAILABLE
             return None
 
@@ -441,10 +446,10 @@ class WMSProviderCheck(OWSProviderCheck):
             layers.extend(sublayers)
 
         # Get layer names
-        layer_names = map(lambda l: (l, l.find("name")), layers)
-        logger.debug("WMS layers offered: {}".format([n.text for l,n in layer_names if n]))
+        layer_names = [(l, l.find("name")) for l in layers]
+        logger.debug("WMS layers offered: {}".format([n.text for l, n in layer_names if n]))
         layer = [l for l, n in layer_names if n is not None and self.layer == n.text]
-        if len(layer) == 0:
+        if not layer:
             # Since layer name is not consistently available for WM(T)S, just skip layer-dependent checks
             self.result = CheckResults.SUCCESS
             return None
@@ -485,15 +490,15 @@ class WMTSProviderCheck(OWSProviderCheck):
         # Flatten nested layers to single list
         layers = contents.findall("layer")
         sublayers = layers
-        while len(sublayers) > 0:
+        while sublayers:
             sublayers = [l for layer in sublayers for l in layer.findall("layer")]
             layers.extend(sublayers)
 
         # Get layer names
-        layer_names = map(lambda l: (l, l.find("title")), layers)
-        logger.debug("WMTS layers offered: {}".format([n.text for l,n in layer_names if n is not None]))
+        layer_names = [(l, l.find("title")) for l in layers]
+        logger.debug("WMTS layers offered: {}".format([n.text for l, n in layer_names if n is not None]))
         layer = [l for l, n in layer_names if n is not None and self.layer == n.text]
-        if len(layer) == 0:
+        if not layer:
             # Since layer name is not consistently available for WM(T)S, just skip layer-dependent checks
             self.result = CheckResults.SUCCESS
             return None
@@ -514,7 +519,7 @@ class WMTSProviderCheck(OWSProviderCheck):
         bbox = map(float, southwest + northeast)
         return bbox
 
-      
+
 class TMSProviderCheck(ProviderCheck):
 
     def __init__(self, service_url, layer, aoi_geojson=None, slug=None):

--- a/eventkit_cloud/utils/provider_check.py
+++ b/eventkit_cloud/utils/provider_check.py
@@ -95,7 +95,7 @@ class ProviderCheck(object):
         self.slug = slug
         self.result = CheckResults.SUCCESS
         self.timeout = 10
-        self.verify = getattr(settings, "DISABLE_SSL_VERIFICATION", False)
+        self.verify = not getattr(settings, "DISABLE_SSL_VERIFICATION", False)
 
         if aoi_geojson is not None and aoi_geojson is not "":
             if isinstance(aoi_geojson, str):

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -70,14 +70,14 @@ class TestAuthResult(TransactionTestCase):
         # If other tests in the future have any issues with httplib (they shouldn't, the patch is transparent,
         # and the original initializer is restored in the finally block), this may be why.
 
-        _orig_HTTPSConnection_init = auth_requests._orig_HTTPSConnection_init
+        orig_init = auth_requests._ORIG_HTTPSCONNECTION_INIT
         try:
             new_orig_init = MagicMock()
-            auth_requests._orig_HTTPSConnection_init = new_orig_init
+            auth_requests._ORIG_HTTPSCONNECTION_INIT = new_orig_init
             # Confirm that the patch is applied
             getenv.return_value = "key and cert contents"
             auth_requests.patch_https("test-provider-slug")
-            self.assertNotEqual(auth_requests._orig_HTTPSConnection_init, httplib.HTTPSConnection.__init__)
+            self.assertNotEqual(auth_requests._ORIG_HTTPSCONNECTION_INIT, httplib.HTTPSConnection.__init__)
             self.assertEqual("_new_init", httplib.HTTPSConnection.__init__
                              .__func__.func_closure[1].cell_contents.__name__)  # complicated because decorator
 
@@ -107,4 +107,4 @@ class TestAuthResult(TransactionTestCase):
                 self.assertEqual(httplib.HTTPSConnection.__init__, new_orig_init)
 
         finally:
-            auth_requests._orig_HTTPSConnection_init = _orig_HTTPSConnection_init
+            auth_requests._ORIG_HTTPSCONNECTION_INIT = orig_init

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -102,5 +102,9 @@ class TestAuthResult(TransactionTestCase):
                 new_orig_init.assert_called_with(ANY, key_file="temp filename", cert_file="temp filename")
                 cert_tempfile.write.assert_called_once_with("key and cert contents")
 
+                # Test removing the patch
+                auth_requests.unpatch_https()
+                self.assertEqual(httplib.HTTPSConnection.__init__, new_orig_init)
+
         finally:
             auth_requests._orig_HTTPSConnection_init = _orig_HTTPSConnection_init

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -33,7 +33,8 @@ class TestAuthResult(TransactionTestCase):
 
         result = req(self.url, slug="test_slug", data=42)
 
-        getenv.assert_called_with("TEST_SLUG_CERT")
+        getenv.assert_any_call("TEST_SLUG_CERT")
+        getenv.assert_any_call("TEST_SLUG_CRED")
         req_patch.assert_called_with(self.url, data=42)
         self.assertEqual("test", result.content)
 
@@ -50,7 +51,8 @@ class TestAuthResult(TransactionTestCase):
         with patch('eventkit_cloud.utils.auth_requests.NamedTemporaryFile', return_value=named_tempfile, create=True):
             result = req(self.url, slug="test_slug", data=42)
 
-        getenv.assert_called_with("test_slug_CERT")
+        getenv.assert_any_call("test_slug_CRED")
+        getenv.assert_any_call("test_slug_CERT")
         cert_tempfile.write.assert_called_once_with("test cert content")
         cert_tempfile.flush.assert_called()
         req_patch.assert_called_with(self.url, data=42, cert="temp filename")
@@ -126,7 +128,7 @@ class TestAuthResult(TransactionTestCase):
 
             # Test removing the patch
             auth_requests.unpatch_mapproxy_opener_cache()
-            self.assertEqual(orig_call, _URLOpenerCache.__call__)
+            self.assertEqual(new_orig_call, _URLOpenerCache.__call__)
 
         finally:
             auth_requests._ORIG_URLOPENERCACHE_CALL = orig_call

--- a/eventkit_cloud/utils/tests/test_auth_requests.py
+++ b/eventkit_cloud/utils/tests/test_auth_requests.py
@@ -75,11 +75,12 @@ class TestAuthResult(TransactionTestCase):
             new_orig_init = MagicMock()
             auth_requests._orig_HTTPSConnection_init = new_orig_init
             # Confirm that the patch is applied
+            getenv.return_value = "key and cert contents"
             auth_requests.patch_https("test-provider-slug")
             self.assertNotEqual(auth_requests._orig_HTTPSConnection_init, httplib.HTTPSConnection.__init__)
-            self.assertEqual("_new_init", httplib.HTTPSConnection.__init__.__func__.func_closure[1].cell_contents.__name__) # complicated because decorator
+            self.assertEqual("_new_init", httplib.HTTPSConnection.__init__
+                             .__func__.func_closure[1].cell_contents.__name__)  # complicated because decorator
 
-            getenv.return_value = "key and cert contents"
             named_tempfile = MagicMock()
             cert_tempfile = MagicMock()
             cert_tempfile.name = "temp filename"

--- a/eventkit_cloud/utils/tests/test_external_service.py
+++ b/eventkit_cloud/utils/tests/test_external_service.py
@@ -54,8 +54,6 @@ class TestGeopackage(TransactionTestCase):
         config_command.assert_called_once_with(cmd)
         self.assertEqual(w2g, real_yaml.load(test_yaml))
 
-    @patch('eventkit_cloud.utils.external_service.validate_seed_conf')
-    @patch('eventkit_cloud.utils.external_service.validate_options')
     @patch('eventkit_cloud.utils.external_service.set_gpkg_contents_bounds')
     @patch('eventkit_cloud.utils.external_service.check_zoom_levels')
     @patch('eventkit_cloud.utils.external_service.check_service')
@@ -66,7 +64,7 @@ class TestGeopackage(TransactionTestCase):
     @patch('eventkit_cloud.utils.external_service.load_config')
     @patch('eventkit_cloud.utils.external_service.get_cache_template')
     @patch('eventkit_cloud.utils.external_service.get_seed_template')
-    def test_convert(self, seed_template, cache_template, load_config, seeder, seeding_config, connections, remove_zoom_levels, check_service, mock_check_zoom_levels, mock_set_gpkg_contents_bounds, validate_options, validate_seed_conf):
+    def test_convert(self, seed_template, cache_template, load_config, seeder, seeding_config, connections, remove_zoom_levels, check_service, mock_check_zoom_levels, mock_set_gpkg_contents_bounds):
         gpkgfile = '/var/lib/eventkit/test.gpkg'
         config = "layers:\r\n - name: imagery\r\n   title: imagery\r\n   sources: [cache]\r\n\r\nsources:\r\n  imagery_wmts:\r\n    type: tile\r\n    grid: webmercator\r\n    url: http://a.tile.openstreetmap.fr/hot/%(z)s/%(x)s/%(y)s.png\r\n\r\ngrids:\r\n  webmercator:\r\n    srs: EPSG:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
         json_config = real_yaml.load(config)
@@ -74,8 +72,6 @@ class TestGeopackage(TransactionTestCase):
         bbox = [-2, -2, 2, 2]
         cache_template.return_value = {'sources': ['imagery_wmts'], 'cache': {'type': 'geopackage', 'filename': '/var/lib/eventkit/test.gpkg'}, 'grids': ['webmercator']}
         seed_template.return_value = {'coverages': {'geom': {'srs': 'EPSG:4326', 'bbox': [-2, -2, 2, 2]}}, 'seeds': {'seed': {'coverages': ['geom'], 'refresh_before': {'minutes': 0}, 'levels': {'to': 10, 'from': 0}, 'caches': ['cache']}}}
-        validate_options.return_value = (False, True)
-        validate_seed_conf.return_value = (False, True)
         self.task_process.return_value = Mock(exitcode=0)
         w2g = ExternalRasterServiceToGeopackage(config=config,
                                gpkgfile=gpkgfile,

--- a/eventkit_cloud/utils/tests/test_external_service.py
+++ b/eventkit_cloud/utils/tests/test_external_service.py
@@ -54,6 +54,7 @@ class TestGeopackage(TransactionTestCase):
         config_command.assert_called_once_with(cmd)
         self.assertEqual(w2g, real_yaml.load(test_yaml))
 
+    @patch('eventkit_cloud.utils.external_service.auth_requests.patch_https')
     @patch('eventkit_cloud.utils.external_service.set_gpkg_contents_bounds')
     @patch('eventkit_cloud.utils.external_service.check_zoom_levels')
     @patch('eventkit_cloud.utils.external_service.check_service')
@@ -64,7 +65,7 @@ class TestGeopackage(TransactionTestCase):
     @patch('eventkit_cloud.utils.external_service.load_config')
     @patch('eventkit_cloud.utils.external_service.get_cache_template')
     @patch('eventkit_cloud.utils.external_service.get_seed_template')
-    def test_convert(self, seed_template, cache_template, load_config, seeder, seeding_config, connections, remove_zoom_levels, check_service, mock_check_zoom_levels, mock_set_gpkg_contents_bounds):
+    def test_convert(self, seed_template, cache_template, load_config, seeder, seeding_config, connections, remove_zoom_levels, check_service, mock_check_zoom_levels, mock_set_gpkg_contents_bounds, patch_https):
         gpkgfile = '/var/lib/eventkit/test.gpkg'
         config = "layers:\r\n - name: imagery\r\n   title: imagery\r\n   sources: [cache]\r\n\r\nsources:\r\n  imagery_wmts:\r\n    type: tile\r\n    grid: webmercator\r\n    url: http://a.tile.openstreetmap.fr/hot/%(z)s/%(x)s/%(y)s.png\r\n\r\ngrids:\r\n  webmercator:\r\n    srs: EPSG:3857\r\n    tile_size: [256, 256]\r\n    origin: nw"
         json_config = real_yaml.load(config)
@@ -95,8 +96,9 @@ class TestGeopackage(TransactionTestCase):
         json_config['sources']['imagery_wmts']['transparent'] = True
         json_config['sources']['imagery_wmts']['on_error'] = {404: {'cache': False,'response': 'transparent'}}
         json_config['services'] = ['demo']
-        
-        check_service.assert_called_once_with(json_config)
+
+        patch_https.assert_called_once_with('imagery')
+        check_service.assert_called_once_with(json_config, 'imagery')
         load_config.assert_called_once_with(mapproxy_config, config_dict=json_config)
         remove_zoom_levels.assert_called_once_with(gpkgfile)
         mock_set_gpkg_contents_bounds.assert_called_once_with(gpkgfile, 'imagery', bbox)
@@ -108,7 +110,7 @@ class TestGeopackage(TransactionTestCase):
 
 class TestHelpers(TransactionTestCase):
 
-    @patch('requests.get')
+    @patch('eventkit_cloud.utils.external_service.auth_requests.get')
     def test_check_service(self, requests_get):
 
         conf_dict = {'sources': {'source1': {'url': 'http://example.com/url'},


### PR DESCRIPTION
Client keys and certificates are specified for each provider via environment variables, e.g.

```
 PROVIDER_SLUG_CERT= '-----BEGIN CERTIFICATE-----
[certificate contents]
-----END CERTIFICATE-----
-----BEGIN PRIVATE KEY-----
[private key contents]
-----END PRIVATE KEY-----'
```

will provide that certificate and key for all requests to the provider with slug `PROVIDER_SLUG`.