### PR TITLE
Optimize runs query

### DIFF
--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -178,7 +178,7 @@ class DataProviderTaskRecordSerializer(serializers.ModelSerializer):
         lookup_field='uid'
     )
 
-    def get_tasks(self):
+    def get_tasks(self, obj):
         return ExportTaskRecordSerializer(many=True, required=False, context=self.context)
 
     class Meta:
@@ -277,7 +277,7 @@ class ExportRunSerializer(serializers.ModelSerializer):
     def get_user(obj):
         return obj.user.username
 
-    def get_provider_tasks(self):
+    def get_provider_tasks(self, obj):
         return DataProviderTaskRecordSerializer(many=True, context=self.context)
 
     def get_zipfile_url(self, obj):

--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -179,7 +179,7 @@ class DataProviderTaskRecordSerializer(serializers.ModelSerializer):
     )
 
     def get_tasks(self, obj):
-        return ExportTaskRecordSerializer(many=True, required=False, context=self.context)
+        return ExportTaskRecordSerializer(obj.tasks, many=True, required=False, context=self.context).data
 
     class Meta:
         model = DataProviderTaskRecord
@@ -278,7 +278,7 @@ class ExportRunSerializer(serializers.ModelSerializer):
         return obj.user.username
 
     def get_provider_tasks(self, obj):
-        return DataProviderTaskRecordSerializer(many=True, context=self.context)
+        return DataProviderTaskRecordSerializer(obj.provider_tasks, many=True, context=self.context).data
 
     def get_zipfile_url(self, obj):
         request = self.context['request']

--- a/eventkit_cloud/api/serializers.py
+++ b/eventkit_cloud/api/serializers.py
@@ -102,6 +102,11 @@ class ExportTaskResultSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField()
     size = serializers.SerializerMethodField()
 
+    def __init__(self, *args, **kwargs):
+        super(ExportTaskResultSerializer, self).__init__(*args, **kwargs)
+        if self.context.get('no_license'):
+            self.fields.pop('url')
+
     class Meta:
         model = FileProducingTaskResult
         fields = ('filename', 'size', 'url', 'deleted')
@@ -167,11 +172,14 @@ class ExportTaskRecordSerializer(serializers.ModelSerializer):
 
 
 class DataProviderTaskRecordSerializer(serializers.ModelSerializer):
-    tasks = ExportTaskRecordSerializer(many=True, required=False)
+    tasks = serializers.SerializerMethodField()
     url = serializers.HyperlinkedIdentityField(
         view_name='api:provider_tasks-detail',
         lookup_field='uid'
     )
+
+    def get_tasks(self):
+        return ExportTaskRecordSerializer(many=True, required=False, context=self.context)
 
     class Meta:
         model = DataProviderTaskRecord
@@ -252,7 +260,7 @@ class ExportRunSerializer(serializers.ModelSerializer):
         lookup_field='uid'
     )
     job = SimpleJobSerializer()  # nest the job details
-    provider_tasks = DataProviderTaskRecordSerializer(many=True)
+    provider_tasks = serializers.SerializerMethodField()
     user = serializers.SerializerMethodField()
     zipfile_url = serializers.SerializerMethodField()
     expiration = serializers.SerializerMethodField
@@ -268,6 +276,9 @@ class ExportRunSerializer(serializers.ModelSerializer):
     @staticmethod
     def get_user(obj):
         return obj.user.username
+
+    def get_provider_tasks(self):
+        return DataProviderTaskRecordSerializer(many=True, context=self.context)
 
     def get_zipfile_url(self, obj):
         request = self.context['request']

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -878,21 +878,6 @@ class TestExportRunViewSet(APITestCase):
         # make sure no runs are returned as they should have been filtered out
         self.assertEquals(0, len(result))
 
-
-
-    @patch('eventkit_cloud.api.views.ExportRunViewSet.validate_licenses')
-    def test_filter_runs_invalid_license(self, mock_validate_licenses):
-        from ...tasks.task_factory import InvalidLicense
-        expected = '/api/runs/filter'
-        url = reverse('api:runs-filter')
-        mock_validate_licenses.side_effect = (InvalidLicense('no license'),)
-        self.assertEquals(expected, url)
-        response = self.client.get(url)
-        self.assertIsNotNone(response)
-        result = response.data
-        self.assertTrue("InvalidLicense" in result[0].get('detail'))
-        self.assertEquals(response.status_code, 400)
-
     def test_filter_runs_no_permissions(self,):
         with patch('eventkit_cloud.jobs.signals.Group') as mock_group:
             mock_group.objects.get.return_value = self.group

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -638,7 +638,6 @@ class ExportRunViewSet(viewsets.ModelViewSet):
     ordering = ('-started_at',)
 
     def get_queryset(self):
-        logger.error(dir(ExportRun))
         prefetched_queryset = ExportRun.objects.filter((Q(user=self.request.user) | Q(job__published=True)) & Q(deleted=False))\
             .select_related('job', 'user')\
             .prefetch_related(Prefetch('provider_tasks',
@@ -755,10 +754,10 @@ class ExportRunViewSet(viewsets.ModelViewSet):
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(page, many=True, context={'request': request, 'no_license': True})
+            serializer = ExportRunSerializer(page, many=True, context={'request': request, 'no_license': True})
             return self.get_paginated_response(serializer.data)
         else:
-            serializer = self.get_serializer(queryset, many=True, context={'request': request, 'no_license': True})
+            serializer = ExportRunSerializer(queryset, many=True, context={'request': request, 'no_license': True})
             return Response(serializer.data, status=status.HTTP_200_OK)
 
     @transaction.atomic

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -639,13 +639,13 @@ class ExportRunViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         logger.error(dir(ExportRun))
-        the_queryset = ExportRun.objects.filter((Q(user=self.request.user) | Q(job__published=True)) & Q(deleted=False))\
+        prefetched_queryset = ExportRun.objects.filter((Q(user=self.request.user) | Q(job__published=True)) & Q(deleted=False))\
             .select_related('job', 'user')\
             .prefetch_related(Prefetch('provider_tasks',
                 queryset=DataProviderTaskRecord.objects.prefetch_related(Prefetch('tasks',
                     queryset=ExportTaskRecord.objects.select_related('result').prefetch_related('exceptions')))))
 
-        return the_queryset
+        return prefetched_queryset
 
     def retrieve(self, request, uid=None, *args, **kwargs):
         """

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -7,7 +7,7 @@ import logging
 import json
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Q
+from django.db.models import Q, Prefetch
 from django.utils.translation import ugettext as _
 from django.contrib.gis.geos import GEOSException, GEOSGeometry
 
@@ -638,7 +638,14 @@ class ExportRunViewSet(viewsets.ModelViewSet):
     ordering = ('-started_at',)
 
     def get_queryset(self):
-        return ExportRun.objects.filter((Q(user=self.request.user) | Q(job__published=True)) & Q(deleted=False))
+        logger.error(dir(ExportRun))
+        the_queryset = ExportRun.objects.filter((Q(user=self.request.user) | Q(job__published=True)) & Q(deleted=False))\
+            .select_related('job', 'user')\
+            .prefetch_related(Prefetch('provider_tasks',
+                queryset=DataProviderTaskRecord.objects.prefetch_related(Prefetch('tasks',
+                    queryset=ExportTaskRecord.objects.select_related('result').prefetch_related('exceptions')))))
+
+        return the_queryset
 
     def retrieve(self, request, uid=None, *args, **kwargs):
         """
@@ -736,7 +743,6 @@ class ExportRunViewSet(viewsets.ModelViewSet):
                 logger.debug(e.detail)
                 return Response(e.detail, status=status.HTTP_400_BAD_REQUEST)
 
-
         search_term = self.request.query_params.get('search_term', None)
         if search_term is not None:
             queryset = queryset.filter(
@@ -747,10 +753,6 @@ class ExportRunViewSet(viewsets.ModelViewSet):
                 )
         )
 
-        try:
-            self.validate_licenses(queryset, user=request.user)
-        except InvalidLicense as il:
-            return Response([{'detail': _(il.message)}], status.HTTP_400_BAD_REQUEST)
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True, context={'request': request})

--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -755,10 +755,10 @@ class ExportRunViewSet(viewsets.ModelViewSet):
 
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(page, many=True, context={'request': request})
+            serializer = self.get_serializer(page, many=True, context={'request': request, 'no_license': True})
             return self.get_paginated_response(serializer.data)
         else:
-            serializer = self.get_serializer(queryset, many=True, context={'request': request})
+            serializer = self.get_serializer(queryset, many=True, context={'request': request, 'no_license': True})
             return Response(serializer.data, status=status.HTTP_200_OK)
 
     @transaction.atomic


### PR DESCRIPTION
The calls the front end makes to /api/runs/filter have been going extremely slow. Optimize them by decreasing database calls.