### PR TITLE
make button same size as create datapack when possible

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackLinkButton.js
@@ -1,57 +1,35 @@
-import React, {PropTypes} from 'react';
+import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
 import { Link } from 'react-router';
 
 export class DataPackLinkButton extends React.Component {
-
-    constructor(props) {
-        super(props);
-    }
-
-    getFontSize() {
-        if(window.innerWidth <= 575) {
-            return '10px';
-        }
-        else if (window.innerWidth <= 767) {
-            return '11px';
-        }
-        else if (window.innerWidth <= 991) {
-            return '12px';
-        }
-        else if(window.innerWidth <= 1199) {
-            return '13px';
-        }
-        else {
-            return '14px';
-        }
-    }
-
     render() {
         const styles = {
             button: {
-                margin: '0px', 
-                minWidth: '50px', 
-                height: '35px', 
-                borderRadius: '0px'
+                margin: '0px',
+                minWidth: '50px',
+                height: '35px',
+                borderRadius: '0px',
+                width: '150px',
             },
             label: {
-                fontSize: this.getFontSize(),
-                paddingLeft: '20px', 
-                paddingRight: '20px', 
-                lineHeight: '35px'
+                fontSize: '12px',
+                paddingLeft: '0px',
+                paddingRight: '0px',
+                lineHeight: '35px',
             },
         };
 
         return (
-            <Link to={'/create'}>
+            <Link to="/create" href="/create">
                 <RaisedButton
-                    className={'qa-DataPackLinkButton-RaisedButton'}
-                    label={"Create DataPack"}
-                    primary={true}
+                    className="qa-DataPackLinkButton-RaisedButton"
+                    label="Create DataPack"
+                    primary
                     labelStyle={styles.label}
                     style={styles.button}
-                    buttonStyle={{borderRadius: '0px', backgroundColor: '#4598bf'}}
-                    overlayStyle={{borderRadius: '0px'}}
+                    buttonStyle={{ borderRadius: '0px', backgroundColor: '#4598bf' }}
+                    overlayStyle={{ borderRadius: '0px' }}
                 />
             </Link>
         );

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.js
@@ -431,13 +431,12 @@ export class UserGroupsPage extends Component {
                 minWidth: '50px',
                 height: '35px',
                 borderRadius: '0px',
-                display: 'flex',
-                float: 'right',
+                width: mobile ? '115px' : '150px',
             },
             label: {
                 fontSize: '12px',
-                paddingLeft: mobile ? '10px' : '20px',
-                paddingRight: mobile ? '10px' : '20px',
+                paddingLeft: '0px',
+                paddingRight: '0px',
                 lineHeight: '35px',
             },
             body: {

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackLinkButton.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackLinkButton.spec.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import sinon from 'sinon';
-import {shallow, mount} from 'enzyme';
+import { mount } from 'enzyme';
 import { Link } from 'react-router';
 import RaisedButton from 'material-ui/RaisedButton';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -11,36 +10,12 @@ describe('DataPackLinkButton component', () => {
 
     it('should render a linked button', () => {
         const wrapper = mount(<DataPackLinkButton />, {
-            context: {muiTheme},
-            childContextTypes: {muiTheme: React.PropTypes.object}
+            context: { muiTheme },
+            childContextTypes: { muiTheme: React.PropTypes.object }
         });
         expect(wrapper.find(Link)).toHaveLength(1);
         expect(wrapper.find(Link).props().to).toEqual('/create');
         expect(wrapper.find(RaisedButton)).toHaveLength(1);
         expect(wrapper.find('span').text()).toEqual('Create DataPack');
-    });
-
-    it('getFontSize should return the font string based on window width', () => {
-        const wrapper = shallow(<DataPackLinkButton/>);
-        
-        window.resizeTo(500, 600);
-        expect(window.innerWidth).toEqual(500);
-        expect(wrapper.instance().getFontSize()).toEqual('10px');
-
-        window.resizeTo(700, 800);
-        expect(window.innerWidth).toEqual(700);
-        expect(wrapper.instance().getFontSize()).toEqual('11px');
-        
-        window.resizeTo(800, 900);
-        expect(window.innerWidth).toEqual(800);
-        expect(wrapper.instance().getFontSize()).toEqual('12px');
-
-        window.resizeTo(1000, 600);
-        expect(window.innerWidth).toEqual(1000);
-        expect(wrapper.instance().getFontSize()).toEqual('13px');
-
-        window.resizeTo(1200, 600);
-        expect(window.innerWidth).toEqual(1200);
-        expect(wrapper.instance().getFontSize()).toEqual('14px');
     });
 });


### PR DESCRIPTION
This PR sets the Create DataPack button and Create Group button to the same size for non-mobile-size screens.
For mobile sized screen the Create DataPack button will be smaller to ensure it fits in the app bar without overflow or wrapping.