### PR TITLE
Only user actions can cancel a request

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/actions/dataPackActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/dataPackActions.js
@@ -2,12 +2,17 @@ import axios from 'axios';
 import cookie from 'react-cookie';
 import types from './actionTypes';
 
-export function getRuns(params, geojson) {
+export function getRuns(params, geojson, isAuto) {
     return (dispatch, getState) => {
         const { runsList } = getState();
+        // if there is already a request in process we need to cancel it
+        // before executing the current request
         if (runsList.fetching && runsList.cancelSource) {
-            // if there is already a request in process we need to cancel it
-            // before executing the current request
+            // if this is not a direct request from the user, dont cancel ongoing requests
+            if (isAuto) {
+                return null;
+            }
+            // if this is a direct user action, it is safe to cancel ongoing requests
             runsList.cancelSource.cancel('Request is no longer valid, cancelling');
         }
 

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
@@ -29,6 +29,7 @@ export class DataPackPage extends React.Component {
         this.handleFilterApply = this.handleFilterApply.bind(this);
         this.handleFilterClear = this.handleFilterClear.bind(this);
         this.changeView = this.changeView.bind(this);
+        this.autoRunRequest = this.autoRunRequest.bind(this);
         this.makeRunRequest = this.makeRunRequest.bind(this);
         this.loadMore = this.loadMore.bind(this);
         this.loadLess = this.loadLess.bind(this);
@@ -60,7 +61,7 @@ export class DataPackPage extends React.Component {
     componentDidMount() {
         this.props.getProviders();
         this.makeRunRequest();
-        this.fetch = setInterval(this.makeRunRequest, 10000);
+        this.fetch = setInterval(this.autoRunRequest, 10000);
         // make sure no geojson upload is in the state
         this.props.resetGeoJSONFile();
     }
@@ -147,7 +148,13 @@ export class DataPackPage extends React.Component {
         this.setState({ order: value, loading: true }, this.makeRunRequest);
     }
 
-    makeRunRequest() {
+    autoRunRequest() {
+        // Call make run request and pass true to indicate this is an auto run request
+        // The auto run request will not have the power to cancel any current requests
+        this.makeRunRequest(true);
+    }
+
+    makeRunRequest(isAuto = false) {
         const status = [];
         Object.keys(this.state.status).forEach((key) => {
             if (this.state.status[key]) {
@@ -177,7 +184,7 @@ export class DataPackPage extends React.Component {
         if (this.state.search) params.search_term = this.state.search.slice(0, 1000);
         if (providers.length) params.providers = providers.join(',');
 
-        return this.props.getRuns(params, this.state.geojson_geometry);
+        return this.props.getRuns(params, this.state.geojson_geometry, isAuto);
     }
 
     handleOwnerFilter(event, index, value) {
@@ -432,8 +439,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        getRuns: (params, geojson) => (
-            dispatch(getRuns(params, geojson))
+        getRuns: (params, geojson, isAuto) => (
+            dispatch(getRuns(params, geojson, isAuto))
         ),
         deleteRuns: (uid) => {
             dispatch(deleteRuns(uid));

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackPage.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackPage.spec.js
@@ -180,7 +180,7 @@ describe('DataPackPage component', () => {
         expect(mountSpy.calledOnce).toBe(true);
         expect(props.getProviders.calledOnce).toBe(true);
         expect(requestStub.calledOnce).toBe(true);
-        expect(intervalStub.calledWith(wrapper.instance().makeRunRequest, 10000)).toBe(true);
+        expect(intervalStub.calledWith(wrapper.instance().autoRunRequest, 10000)).toBe(true);
         expect(props.resetGeoJSONFile.calledOnce).toBe(true);
         mountSpy.restore();
         requestStub.restore();
@@ -301,6 +301,16 @@ describe('DataPackPage component', () => {
         expect(stateSpy.calledOnce).toBe(true);
         expect(stateSpy.calledWith({order: 'job__name', loading: true}, wrapper.instance().makeRunRequest))
         stateSpy.restore();
+    });
+
+    it('autoRunRequest should call makeRunRequest with true', () => {
+        const props = getProps();
+        const wrapper = getWrapper(props);
+        const stub = sinon.stub(wrapper.instance(), 'makeRunRequest');
+        wrapper.instance().autoRunRequest();
+        expect(stub.calledOnce).toBe(true);
+        expect(stub.calledWith(true)).toBe(true);
+        stub.restore();
     });
 
     it('makeRunRequest should build a params object and pass it to props.getRuns', () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/actions/dataPackActions.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/actions/dataPackActions.spec.js
@@ -42,11 +42,24 @@ describe('DataPackList actions', () => {
         const cancel = sinon.spy();
         const cancelSource = { cancel };
         const store = mockStore({ runsList: { fetching: true, cancelSource } });
-        return store.dispatch(actions.getRuns())
+        return store.dispatch(actions.getRuns({}, {}, false))
             .then(() => {
                 expect(cancel.calledOnce).toBe(true);
                 expect(cancel.calledWith('Request is no longer valid, cancelling')).toBe(true);
             });
+    });
+
+    it('getRuns should NOT cancel an active request', () => {
+        const mock = new MockAdapter(axios, { delayResponse: 1 });
+        mock.onPost('/api/runs/filter').reply(200, expectedRuns, {
+            link: '<www.link.com>; rel="next",something else', 'content-range': 'range 1-12/24',
+        });
+        const cancel = sinon.spy();
+        const cancelSource = { cancel };
+        const store = mockStore({ runsList: { fetching: true, cancelSource } });
+        const ret = store.dispatch(actions.getRuns({}, {}, true));
+        expect(cancel.called).toBe(false);
+        expect(ret).toBe(null);
     });
 
     it('getRuns should handle the axios request being cancelled', () => {


### PR DESCRIPTION
The PR updates the getRuns action to accept a bool indicating if the run is being called as a result of a user action or as part of the continuous polling. Only user actions will allow in progress requests to be cancelled.
Polling requests will just return null and allow the current request to complete.