### PR TITLE
Make sure old timers are always cleared

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
@@ -31,7 +31,6 @@ export class DataCartDetails extends Component {
             minDate: null,
             maxDate: null,
             permission: null,
-            status: '',
         };
     }
 
@@ -153,7 +152,7 @@ export class DataCartDetails extends Component {
             statusFontColor = '#ce4427';
         }
 
-        const rerunDisabled = this.state.status === 'SUBMITTED' || this.props.user.data.user.username !== this.props.cartDetails.user;
+        const rerunDisabled = this.props.cartDetails.status === 'SUBMITTED' || this.props.user.data.user.username !== this.props.cartDetails.user;
 
         return (
             <div>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
@@ -73,6 +73,7 @@ export class StatusDownload extends React.Component {
                 if (clearTimer === 0) {
                     window.clearInterval(this.timer);
                     this.timer = null;
+                    window.clearTimeout(this.timeout);
                     this.timeout = window.setTimeout(() => {
                         this.props.getDatacartDetails(this.props.params.jobuid);
                     }, 270000);
@@ -127,6 +128,7 @@ export class StatusDownload extends React.Component {
     }
 
     startTimer() {
+        window.clearInterval(this.timer);
         this.timer = window.setInterval(() => {
             this.props.getDatacartDetails(this.props.params.jobuid);
         }, 5000);


### PR DESCRIPTION
This PR _should_ fix the issues with datapacks switching on the status and download page. It also fixes the re-run button, which should be disabled when the datapack is still running.
The datapacks were switching because we would create a new interval or timeout and assign its id to a variable without making sure anything assigned to the variable already was cleared. Clearing it should fix the issue.

*No UI changes*