### PR TITLE
use username and display no email message

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserTableRowColumn.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserTableRowColumn.js
@@ -106,6 +106,12 @@ export class UserTableRowColumn extends Component {
             ...rest
         } = this.props;
 
+        let name = user.user.username;
+        if (user.user.first_name && user.user.last_name) {
+            name = `${user.user.first_name} ${user.user.last_name}`;
+        }
+        const email = user.user.email || 'No email provided';
+
         return (
             <TableRowColumn
                 {...rest}
@@ -115,10 +121,10 @@ export class UserTableRowColumn extends Component {
                 <div style={{ display: 'flex' }}>
                     <div style={{ display: 'flex', flexWrap: 'wrap', flex: '1 1 auto' }}>
                         <div className="qa-UserTableRowColumn-name" style={{ flexBasis: '100%', flexWrap: 'wrap', wordBreak: 'break-word' }}>
-                            <strong>{`${user.user.first_name} ${user.user.last_name}`}</strong>
+                            <strong>{name}</strong>
                         </div>
                         <div className="qa-UserTableRowColumn-email" style={{ flexBasis: '100%', flexWrap: 'wrap', wordBreak: 'break-word' }}>
-                            {user.user.email}
+                            {email}
                         </div>
                     </div>
                     {showAdminLabel ?

--- a/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/UserTableRowColumn.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/UserTableRowColumn.spec.js
@@ -48,6 +48,16 @@ describe('UserTableRowColumn component', () => {
         expect(wrapper.find(GroupsDropDownMenu)).toHaveLength(1);
     });
 
+    it('should render username and no email text', () => {
+        const props = getProps();
+        props.user.user.first_name = '';
+        props.user.user.last_name = '';
+        props.user.user.email = '';
+        const wrapper = getWrapper(props);
+        expect(wrapper.find('.qa-UserTableRowColumn-name').text()).toEqual(props.user.user.username);
+        expect(wrapper.find('.qa-UserTableRowColumn-email').text()).toEqual('No email provided');
+    });
+
     it('handleOpen should preventDefault, stopPropagation, and setState', () => {
         const fakeEvent = {
             preventDefault: sinon.spy(),


### PR DESCRIPTION
This PR adds fallbacks for displaying user info on the Members and Groups page.
If the user does not have first and last name, the username will be displayed.
If the user does not have an email address, a no-email message will be displayed instead.
![image](https://user-images.githubusercontent.com/16799449/38503045-0227de98-3bdf-11e8-8c16-c79ad9366dfa.png)
![image](https://user-images.githubusercontent.com/16799449/38503062-0dc8a48a-3bdf-11e8-9214-b835a0321c86.png)
