### PR TITLE
add count to new and ungrouped

### DIFF
--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -1,7 +1,7 @@
 """Provides classes for handling API requests."""
 # -*- coding: utf-8 -*-
 from collections import OrderedDict
-from datetime import datetime,timedelta
+from datetime import datetime, timedelta, date
 from dateutil import parser
 import logging
 import json
@@ -944,9 +944,19 @@ class UserDataViewSet(viewsets.GenericViewSet):
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def list(self, request,  *args, **kwargs):
-        queryset = self.filter_queryset(self.get_queryset())
-        serializer = UserDataSerializer(queryset, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        full_queryset = self.get_queryset()
+        queryset = full_queryset.exclude(id=request.user.id)
+        total = len(queryset)
+        delta = date.today() - timedelta(days=14)
+        new = len(queryset.filter(date_joined__gte=delta))
+        not_grouped = 0
+        for user in queryset:
+            if not len(GroupPermission.objects.filter(user=user)):
+                not_grouped += 1
+        headers = {'Total-Users': total, 'New-Users': new, 'Not-Grouped-Users': not_grouped}
+        filtered_queryset = self.filter_queryset(full_queryset)
+        serializer = UserDataSerializer(filtered_queryset, many=True)
+        return Response(serializer.data, headers=headers, status=status.HTTP_200_OK)
 
     @list_route(methods=['post','get'])
     def members(self, request, *args, **kwargs):
@@ -966,7 +976,7 @@ class UserDataViewSet(viewsets.GenericViewSet):
         for group in groups:
             serializer = GroupSerializer(group)
             for username in serializer.get_members(group):
-                if  not username in targetnames: targetnames.append(username)
+                if not username in targetnames: targetnames.append(username)
 
 
         users = User.objects.filter(username__in=targetnames).all()

--- a/eventkit_cloud/ui/static/ui/app/actions/userActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActions.js
@@ -123,9 +123,21 @@ export function getUsers(params) {
             method: 'GET',
             headers: { 'X-CSRFToken': csrfmiddlewaretoken },
         }).then((response) => {
+            // get the total, new, and ungrouped counts from the header
+            const totalUsers = Number(response.headers['total-users']);
+            const newUsers = Number(response.headers['new-users']);
+            const ungroupedUsers = Number(response.headers['not-grouped-users']);
+
             // filter out the current user from the list
             const users = response.data.filter(user => (user.user.username !== loggedInUser.username));
-            dispatch({ type: actions.FETCHED_USERS, users });
+            
+            dispatch({
+                type: actions.FETCHED_USERS,
+                users,
+                total: totalUsers,
+                new: newUsers,
+                ungrouped: ungroupedUsers,
+            });
         }).catch((error) => {
             dispatch({ type: actions.FETCH_USERS_ERROR, error: error.response.data });
         });

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/GroupsDrawer.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/GroupsDrawer.js
@@ -93,13 +93,13 @@ export class GroupsDrawer extends Component {
                             value="all"
                         />
                         <MenuItem
-                            primaryText="New"
+                            primaryText={`New (${this.props.newCount})`}
                             style={styles.simpleMenuItem}
                             className="qa-GroupsDrawer-new"
                             value="new"
                         />
                         <MenuItem
-                            primaryText="Not Grouped"
+                            primaryText={`Not Grouped (${this.props.ungroupedCount})`}
                             style={styles.simpleMenuItem}
                             className="qa-GroupsDrawer-notGrouped"
                             value="ungrouped"
@@ -221,6 +221,8 @@ GroupsDrawer.propTypes = {
         administrators: PropTypes.arrayOf(PropTypes.string),
     })).isRequired,
     usersCount: PropTypes.number.isRequired,
+    newCount: PropTypes.number.isRequired,
+    ungroupedCount: PropTypes.number.isRequired,
     onNewGroupClick: PropTypes.func.isRequired,
     onSharedInfoClick: PropTypes.func.isRequired,
     onLeaveGroupClick: PropTypes.func.isRequired,

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.js
@@ -733,6 +733,8 @@ export class UserGroupsPage extends Component {
                     ownedGroups={ownedGroups}
                     sharedGroups={sharedGroups}
                     usersCount={this.props.users.total}
+                    newCount={this.props.users.new}
+                    ungroupedCount={this.props.users.ungrouped}
                     className="qa-UserGroupsPage-drawer"
                     onNewGroupClick={this.handleCreateOpen}
                     onSharedInfoClick={this.showSharedInfoDialog}
@@ -882,6 +884,8 @@ UserGroupsPage.propTypes = {
         fetched: PropTypes.bool,
         error: PropTypes.string,
         total: PropTypes.number,
+        new: PropTypes.number,
+        ungrouped: PropTypes.number,
     }).isRequired,
     getGroups: PropTypes.func.isRequired,
     deleteGroup: PropTypes.func.isRequired,

--- a/eventkit_cloud/ui/static/ui/app/reducers/userReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/userReducer.js
@@ -40,6 +40,8 @@ export const usersState = {
     fetched: false,
     error: null,
     total: 0,
+    new: 0,
+    ungrouped: 0,
 };
 
 export function usersReducer(state = usersState, action) {
@@ -57,7 +59,9 @@ export function usersReducer(state = usersState, action) {
             fetching: false,
             fetched: true,
             users: action.users,
-            total: state.total || action.users.length,
+            total: action.total,
+            new: action.new,
+            ungrouped: action.ungrouped,
         };
     case types.FETCH_USERS_ERROR:
         return {
@@ -66,6 +70,8 @@ export function usersReducer(state = usersState, action) {
             fetched: false,
             error: action.error,
             total: 0,
+            new: 0,
+            ungrouped: 0,
         };
     default:
         return state;

--- a/eventkit_cloud/ui/static/ui/app/tests/actions/userActions.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/actions/userActions.spec.js
@@ -205,7 +205,12 @@ describe('userActions actions', () => {
             { user: { name: 'user2', username: 'user2' } },
             { user: { name: 'user3', username: 'user3' } },
         ];
-        mock.onGet('/api/users').reply(200, users);
+        const headers = {
+            'total-users': '3',
+            'new-users': '2',
+            'not-grouped-users': '1',
+        };
+        mock.onGet('/api/users').reply(200, users, headers);
 
         const expectedUsers = [
             users[1],
@@ -214,7 +219,13 @@ describe('userActions actions', () => {
 
         const expectedActions = [
             { type: types.FETCHING_USERS },
-            { type: types.FETCHED_USERS, users: expectedUsers },
+            {
+                type: types.FETCHED_USERS,
+                users: expectedUsers,
+                total: 3,
+                new: 2,
+                ungrouped: 1,
+            },
         ];
 
         const store = mockStore({

--- a/eventkit_cloud/ui/static/ui/app/tests/reducers/userReducer.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/reducers/userReducer.spec.js
@@ -117,22 +117,29 @@ describe('usersReducer', () => {
 
     it('FETCHED_USER should return fetched true, the users, and user total', () => {
         const users = [{ name: 'one' }, { name: 'two' }];
-        const total = 2;
         expect(usersReducer(
             {
                 ...usersState,
                 fetching: true,
+                total: 0,
+                new: 0,
+                ungrouped: 0,
             },
             {
                 type: types.FETCHED_USERS,
                 users,
-                total,
+                total: 3,
+                new: 2,
+                ungrouped: 1,
+
             },
         )).toEqual({
             ...usersState,
             fetched: true,
             users,
-            total,
+            total: 3,
+            new: 2,
+            ungrouped: 1,
         });
     });
 


### PR DESCRIPTION
This PR adds a count next to the New and Not Grouped sections of the Users/Groups page
![image](https://user-images.githubusercontent.com/16799449/38566793-916fe8ba-3cb2-11e8-9c95-c7733eb5d850.png)
