### PR TITLE
426 aoi size on export info

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -693,7 +693,12 @@ export class ExportInfo extends React.Component {
                                 Area of Interest (AOI)
                             </div>
                             <div style={style.sectionBottom}>
-                                <CustomTableRow title="Area" data="1,000 sq km" containerStyle={{ fontSize: '16px' }} />
+                                <CustomTableRow
+                                    className="qa-ExportInfo-area"
+                                    title="Area"
+                                    data={this.props.exportInfo.areaStr}
+                                    containerStyle={{ fontSize: '16px' }}
+                                />
                                 <div style={style.mapCard}>
                                     <Card
                                         expandable

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -29,6 +29,7 @@ import ProviderStatusIcon from './ProviderStatusIcon';
 import { updateExportInfo, stepperNextEnabled, stepperNextDisabled } from '../../actions/exportsActions';
 import BaseDialog from '../Dialog/BaseDialog';
 import CustomTextField from '../CustomTextField';
+import CustomTableRow from '../CustomTableRow';
 import BaseTooltip from '../BaseTooltip';
 import { getSqKmString } from '../../utils/generic';
 import ol3mapCss from '../../styles/ol3map.css';
@@ -400,17 +401,50 @@ export class ExportInfo extends React.Component {
                 color: '#4999BD',
                 cursor: 'pointer',
             },
+            listItem: {
+                fontWeight: 'normal',
+                padding: '16px 16px 16px 45px',
+                fontSize: '16px',
+                marginBottom: '0',
+            },
+            providerLicense: {
+                fontSize: '13px',
+                borderTop: '1px solid rgb(224, 224, 224)',
+                paddingLeft: '66px',
+                marginLeft: '0',
+            },
+            serviceDescription: {
+                fontSize: '13px',
+                borderTop: '1px solid rgb(224, 224, 224)',
+                paddingLeft: '44px',
+                marginLeft: '0',
+            },
             sectionBottom: {
-                paddingBottom: '50px',
+                paddingBottom: '30px',
             },
             checkboxLabel: {
                 display: 'inline-flex',
             },
+            infoIcon: {
+                marginLeft: '10px',
+                height: '24px',
+                width: '24px',
+                cursor: 'pointer',
+                display: 'inlineBlock',
+                fill: '#4598bf',
+                verticalAlign: 'middle',
+            },
             mapCard: {
-                paddingBottom: '20px',
+                padding: '15px 0px 20px',
             },
             map: {
                 width: '100%',
+            },
+            editAoi: {
+                fontSize: '15px',
+                fontWeight: 'normal',
+                verticalAlign: 'top',
+                cursor: 'pointer',
             },
         };
 
@@ -540,7 +574,7 @@ export class ExportInfo extends React.Component {
                                                         </BaseDialog>
                                                     </div>
                                                 }
-                                                style={{ fontSize: '13px', borderTop: '1px solid rgb(224, 224, 224)', paddingLeft: '66px', marginLeft: '0' }}
+                                                style={style.providerLicense}
                                             />);
                                         }
                                         nestedItems.push(<ListItem
@@ -548,7 +582,7 @@ export class ExportInfo extends React.Component {
                                             key={nestedItems.length}
                                             primaryText={<div style={{ whiteSpace: 'pre-wrap' }}>{provider.service_description}</div>}
                                             disabled
-                                            style={{ fontSize: '13px', borderTop: '1px solid rgb(224, 224, 224)', paddingLeft: '44px', marginLeft: '0' }}
+                                            style={style.serviceDescription}
                                         />);
 
                                         const backgroundColor = (ix % 2 === 0) ? 'whitesmoke' : 'white';
@@ -556,7 +590,7 @@ export class ExportInfo extends React.Component {
                                         return (<ListItem
                                             className="qa-ExportInfo-ListItem"
                                             key={provider.uid}
-                                            style={{ backgroundColor, fontWeight: 'normal', padding: '16px 16px 16px 45px', fontSize: '16px', marginBottom: '0' }}
+                                            style={{ ...style.listItem, backgroundColor }}
                                             nestedListStyle={{ padding: '0px', backgroundColor }}
                                             primaryText={
                                                 <div>
@@ -609,14 +643,17 @@ export class ExportInfo extends React.Component {
                                         style={{ display: 'inlineBlock' }}
                                         disabled
                                         checkedIcon={<ActionCheckCircle className="qa-ExportInfo-ActionCheckCircle-projection" />}
-                                    /><Info className="qa-ExportInfo-Info-projection" onTouchTap={this.handleProjectionsOpen} style={{ marginLeft: '10px', height: '24px', width: '24px', cursor: 'pointer', display: 'inlineBlock', fill: '#4598bf', verticalAlign: 'middle' }} />
+                                    />
+                                    <Info className="qa-ExportInfo-Info-projection" onTouchTap={this.handleProjectionsOpen} style={style.infoIcon} />
                                     <BaseDialog
                                         show={this.state.projectionsDialogOpen}
                                         title="Projection Information"
                                         onClose={this.handleProjectionsClose}
                                     >
                                         <div style={{ paddingBottom: '10px', wordWrap: 'break-word' }} className="qa-ExportInfo-dialog-projection">
-                                            All geospatial data provided by EventKit are in the World Geodetic System 1984 (WGS 84) projection. This projection is also commonly known by its EPSG code: 4326. Additional projection support will be added in subsequent versions.
+                                            All geospatial data provided by EventKit are in the World Geodetic System 1984 (WGS 84) projection.
+                                             This projection is also commonly known by its EPSG code: 4326.
+                                             Additional projection support will be added in subsequent versions.
                                         </div>
                                     </BaseDialog>
                                 </div>
@@ -637,47 +674,56 @@ export class ExportInfo extends React.Component {
                                             defaultChecked
                                             disabled
                                             checkedIcon={<ActionCheckCircle />}
-                                        /><Info onTouchTap={this.handleFormatsOpen} style={{ marginLeft: '10px', height: '24px', width: '24px', cursor: 'pointer', display: 'inlineBlock', fill: '#4598bf', verticalAlign: 'middle' }}/>
+                                        />
+                                        <Info onTouchTap={this.handleFormatsOpen} style={style.infoIcon} />
                                         <BaseDialog
                                             show={this.state.formatsDialogOpen}
                                             title="Format Information"
                                             onClose={this.handleFormatsClose}
-                                        ><div style={{ paddingBottom: '20px', wordWrap: 'break-word' }}>
-                                            EventKit provides all geospatial data in the GeoPackage (.gpkg) format. Additional format support will be added in subsequent versions.</div>
+                                        >
+                                            <div style={{ paddingBottom: '20px', wordWrap: 'break-word' }}>
+                                                EventKit provides all geospatial data in the GeoPackage (.gpkg) format.
+                                                 Additional format support will be added in subsequent versions.
+                                            </div>
                                         </BaseDialog>
                                     </div>
                                 ))}
                             </div>
-
-                            <div style={style.mapCard}>
-                                <Card
-                                    expandable
-                                    className="qa-ExportInfo-Card-map"
-                                    onExpandChange={this.expandedChange}
-                                >
-                                    <CardHeader
-                                        className="qa-ExportInfo-CardHeader-map"
-                                        title="Selected Area of Interest"
-                                        actAsExpander={false}
-                                        showExpandableButton
-                                        style={{ padding: '12px 10px 10px', backgroundColor: 'rgba(179, 205, 224, .2)' }}
-                                        textStyle={{ paddingRight: '6px', fontWeight: 'bold', fontSize: '18px' }}
-                                    >
-                                        <a
-                                            onClick={this.props.handlePrev}
-                                            style={{ fontSize: '15px', fontWeight: 'normal', verticalAlign: 'top', cursor: 'pointer' }}
-                                        >
-                                            Edit
-                                        </a>
-                                    </CardHeader>
-                                    <CardText
-                                        className="qa-ExportInfo-CardText-map"
+                            <div id="aoiHeader" className="qa-ExportInfo-AoiHeader" style={style.heading}>
+                                Area of Interest (AOI)
+                            </div>
+                            <div style={style.sectionBottom}>
+                                <CustomTableRow title="Area" data="1,000 sq km" containerStyle={{ fontSize: '16px' }} />
+                                <div style={style.mapCard}>
+                                    <Card
                                         expandable
-                                        style={{ padding: '5px', backgroundColor: 'rgba(179, 205, 224, .2)' }}
+                                        className="qa-ExportInfo-Card-map"
+                                        onExpandChange={this.expandedChange}
                                     >
-                                        <div id="infoMap" style={style.map} />
-                                    </CardText>
-                                </Card>
+                                        <CardHeader
+                                            className="qa-ExportInfo-CardHeader-map"
+                                            title="Selected Area of Interest"
+                                            actAsExpander={false}
+                                            showExpandableButton
+                                            style={{ padding: '12px 10px 10px', backgroundColor: 'rgba(179, 205, 224, .2)' }}
+                                            textStyle={{ paddingRight: '6px', fontWeight: 'bold', fontSize: '18px' }}
+                                        >
+                                            <a
+                                                onClick={this.props.handlePrev}
+                                                style={style.editAoi}
+                                            >
+                                                Edit
+                                            </a>
+                                        </CardHeader>
+                                        <CardText
+                                            className="qa-ExportInfo-CardText-map"
+                                            expandable
+                                            style={{ padding: '5px', backgroundColor: 'rgba(179, 205, 224, .2)' }}
+                                        >
+                                            <div id="infoMap" style={style.map} />
+                                        </CardText>
+                                    </Card>
+                                </div>
                             </div>
                         </Paper>
                     </form>

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
@@ -16,11 +16,13 @@ import Zoom from 'ol/control/zoom';
 import Paper from 'material-ui/Paper';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 import CustomScrollbar from '../CustomScrollbar';
+import CustomTableRow from '../CustomTableRow';
 import ol3mapCss from '../../styles/ol3map.css';
 
 export class ExportSummary extends Component {
     constructor(props) {
         super(props);
+        this.expandedChange = this.expandedChange.bind(this);
         this.state = {
             expanded: false,
         };
@@ -137,34 +139,6 @@ export class ExportSummary extends Component {
                 paddingTop: '25px',
                 paddingBottom: '10px',
             },
-            tdHeading: {
-                verticalAlign: 'top',
-                padding: '10px',
-                height: '35px',
-                fontSize: '16px',
-                width: '33%',
-                backgroundColor: '#f8f8f8',
-                fontWeight: 'bold',
-                color: 'black',
-            },
-            tdData: {
-                padding: '10px',
-                height: '35px',
-                fontSize: '16px',
-                width: '66%',
-                backgroundColor: '#f8f8f8',
-                fontWeight: 'normal',
-                color: '#8b9396',
-                wordWrap: 'break-word',
-            },
-            table: {
-                width: '100%',
-                height: '100%',
-                border: '0px solid black',
-                borderSpacing: '5px',
-                borderCollapse: 'separate',
-                tableLayout: 'fixed',
-            },
             mapCard: {
                 paddingBottom: '20px',
                 paddingTop: '15px',
@@ -196,47 +170,45 @@ export class ExportSummary extends Component {
                                 <div id="export-information-heading" className="qa-ExportSummary-exportHeading" style={style.exportHeading}>
                                     Export Information
                                 </div>
-                                <table style={style.table} id="export-information">
-                                    <tbody>
-                                        <tr id="name" className="qa-ExportSummary-tr-name">
-                                            <td style={style.tdHeading}>Name</td>
-                                            <td style={style.tdData}>{this.props.exportName}</td>
-                                        </tr>
-                                        <tr id="description" className="qa-ExportSummary-tr-description">
-                                            <td style={style.tdHeading}>Description</td>
-                                            <td style={style.tdData}>{this.props.datapackDescription}</td>
-                                        </tr>
-                                        <tr id="project" className="qa-ExportSummary-tr-category">
-                                            <td style={style.tdHeading}>Project&nbsp;/ Category</td>
-                                            <td style={style.tdData}>{this.props.projectName}</td>
-                                        </tr>
-                                        <tr id="formats" className="qa-ExportSummary-tr-formats">
-                                            <td style={style.tdHeading}>File Formats</td>
-                                            <td style={style.tdData}>{formatDesc}</td>
-                                        </tr>
-                                        <tr id="layers" className="qa-ExportSummary-tr-layers">
-                                            <td style={style.tdHeading} rowSpan={providers.length}>Data Sources</td>
-                                            <td style={style.tdData}>{providers.map(provider => <p key={provider.uid}>{provider.name}</p>)}</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
+                                <CustomTableRow
+                                    className="qa-ExportSummary-name"
+                                    title="Name"
+                                    data={this.props.exportName}
+                                />
+                                <CustomTableRow
+                                    className="qa-ExportSummary-description"
+                                    title="Description"
+                                    data={this.props.datapackDescription}
+                                />
+                                <CustomTableRow
+                                    className="qa-ExportSummary-project"
+                                    title="Project / Category"
+                                    data={this.props.projectName}
+                                />
+                                <CustomTableRow
+                                    className="qa-ExportSummary-formats"
+                                    title="File Formats"
+                                    data={formatDesc}
+                                />
+                                <CustomTableRow
+                                    className="qa-ExportSummary-sources"
+                                    title="Data Sources"
+                                    data={providers.map(provider => <p style={{ width: '100%' }} key={provider.uid}>{provider.name}</p>)}
+                                />
                                 <div id="aoi-heading" className="qa-ExportSummary-aoiHeading" style={style.exportHeading}>
                                     Area of Interest (AOI)
                                 </div>
-                                <table style={style.table} id="aoi-area" className="qa-ExportSummary-tr-area">
-                                    <tbody>
-                                        <tr>
-                                            <td style={style.tdHeading}>Area</td>
-                                            <td style={style.tdData}>{this.props.areaStr}</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
+                                <CustomTableRow
+                                    className="qa-ExportsSummary-area"
+                                    title="Area"
+                                    data={this.props.areaStr}
+                                />
                             </div>
                             <div id="aoi-map" className="qa-ExportSummary-map" style={style.mapCard}>
                                 <Card
                                     className="qa-ExportSummary-Card"
                                     expandable
-                                    onExpandChange={this.expandedChange.bind(this)}
+                                    onExpandChange={this.expandedChange}
                                 >
                                     <CardHeader
                                         className="qa-ExportSummary-CardHeader"
@@ -276,7 +248,7 @@ function mapStateToProps(state) {
 }
 
 ExportSummary.contextTypes = {
-    config: PropTypes.object
+    config: PropTypes.object,
 };
 
 ExportSummary.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/components/CustomTableRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CustomTableRow.js
@@ -1,13 +1,13 @@
 import React, { Component, PropTypes } from 'react';
 
-export class DataPackTableRow extends Component {
+export class CustomTableRow extends Component {
     render() {
         const styles = {
             container: {
                 display: 'flex',
                 flex: '0 1 auto',
                 width: '100%',
-                padding: '5px',
+                padding: '5px 0px',
                 ...this.props.containerStyle,
             },
             title: {
@@ -22,6 +22,7 @@ export class DataPackTableRow extends Component {
             data: {
                 display: 'flex',
                 flex: '1 1 auto',
+                flexWrap: 'wrap',
                 backgroundColor: '#f8f8f8',
                 color: '#8b9396',
                 paddingRight: '10px',
@@ -36,33 +37,27 @@ export class DataPackTableRow extends Component {
 
         return (
             <div
-                className="qa-DataPackTableRow"
+                className="qa-CustomTableRow"
                 style={styles.container}
             >
-                <div
-                    style={styles.title}
-                >
+                <div style={styles.title}>
                     <strong>{this.props.title}</strong>
                 </div>
-                <div
-                    style={styles.data}
-                >
-
-                        {this.props.data}
-
+                <div style={styles.data}>
+                    {this.props.data}
                 </div>
             </div>
         );
     }
 }
 
-DataPackTableRow.defaultProps = {
+CustomTableRow.defaultProps = {
     containerStyle: {},
     titleStyle: {},
     dataStyle: {},
 };
 
-DataPackTableRow.propTypes = {
+CustomTableRow.propTypes = {
     title: PropTypes.string.isRequired,
     data: PropTypes.oneOfType([
         PropTypes.string,
@@ -74,4 +69,4 @@ DataPackTableRow.propTypes = {
     dataStyle: PropTypes.object,
 };
 
-export default DataPackTableRow;
+export default CustomTableRow;

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartDetails.js
@@ -1,7 +1,7 @@
 import React, { PropTypes, Component } from 'react';
 import moment from 'moment';
 import DataPackDetails from './DataPackDetails';
-import DataPackTableRow from './DataPackTableRow';
+import CustomTableRow from '../CustomTableRow';
 import DataPackStatusTable from './DataPackStatusTable';
 import DataPackOptions from './DataPackOptions';
 import DataPackGeneralTable from './DataPackGeneralTable';
@@ -54,7 +54,7 @@ export class DataCartDetails extends Component {
                 alignContent: 'flex-start',
                 color: 'black',
                 fontWeight: 'bold',
-                marginBottom: '10px',
+                marginBottom: '5px',
             },
         };
 
@@ -80,8 +80,8 @@ export class DataCartDetails extends Component {
 
         return (
             <div>
-                <div style={{ marginLeft: '-5px', marginTop: '-5px' }} className="qa-DataCartDetails-div-name">
-                    <DataPackTableRow
+                <div className="qa-DataCartDetails-div-name">
+                    <CustomTableRow
                         className="qa-DataCartDetails-name"
                         title="Name"
                         data={this.props.cartDetails.job.name}

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartInfoTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataCartInfoTable.js
@@ -1,24 +1,24 @@
 import React, { PropTypes, Component } from 'react';
 import moment from 'moment';
-import DataPackTableRow from './DataPackTableRow';
+import CustomTableRow from '../CustomTableRow';
 
 export class DataCartInfoTable extends Component {
     render() {
         return (
-            <div style={{ marginTop: '-5px', marginLeft: '-5px' }}>
-                <DataPackTableRow
+            <div>
+                <CustomTableRow
                     title="Run By"
                     data={this.props.dataPack.user}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     title="Run Id"
                     data={this.props.dataPack.uid}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     title="Started"
                     data={moment(this.props.dataPack.started_at).format('h:mm:ss a, MMMM Do YYYY')}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     title="Finished"
                     data={this.props.dataPack.finished_at === null ? 'Currently Processing...' : moment(this.props.dataPack.finished_at).format('h:mm:ss a, MMMM Do YYYY')}
                 />

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackAoiInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackAoiInfo.js
@@ -10,7 +10,7 @@ import Tile from 'ol/layer/tile';
 import Attribution from 'ol/control/attribution';
 import ScaleLine from 'ol/control/scaleline';
 import Zoom from 'ol/control/zoom';
-import DataPackTableRow from './DataPackTableRow';
+import CustomTableRow from '../CustomTableRow';
 import { getSqKmString } from '../../utils/generic';
 import ol3mapCss from '../../styles/ol3map.css';
 
@@ -82,12 +82,11 @@ export class DataPackAoiInfo extends Component {
     render() {
         return (
             <div>
-                <DataPackTableRow
+                <CustomTableRow
                     className="qa-DataPackAoiInfo-area"
                     title="Area"
                     data={getSqKmString(this.props.extent)}
                     dataStyle={{ wordBreak: 'break-all' }}
-                    containerStyle={{ paddingLeft: '0px' }}
                 />
                 <div className="qa-DataPackAoiInfo-div-map" id="summaryMap" style={{ maxHeight: '400px', marginTop: '10px' }} />
             </div>

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
@@ -1,6 +1,6 @@
 import React, { PropTypes, Component } from 'react';
 import Info from 'material-ui/svg-icons/action/info';
-import DataPackTableRow from './DataPackTableRow';
+import CustomTableRow from '../CustomTableRow';
 import BaseDialog from '../Dialog/BaseDialog';
 
 export class DataCartGeneralTable extends Component {
@@ -67,18 +67,18 @@ export class DataCartGeneralTable extends Component {
         };
 
         return (
-            <div style={{ marginTop: '-5px', marginLeft: '-5px' }} className="qa-DataPackGeneralTable">
-                <DataPackTableRow
+            <div className="qa-DataPackGeneralTable">
+                <CustomTableRow
                     className="qa-DataPackGeneralTable-description"
                     title="Description"
                     data={this.props.dataPack.job.description}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     className="qa-DataPackGeneralTable-project"
                     title="Project / Category"
                     data={this.props.dataPack.job.event}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     className="qa-DataPackGeneralTable-sources"
                     title="Data Sources"
                     dataStyle={{ flexWrap: 'wrap', padding: '5px 10px 5px', display: 'grid' }}
@@ -106,7 +106,7 @@ export class DataCartGeneralTable extends Component {
                         ))
                     }
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     className="qa-DataPackGeneralTable-formats"
                     title="File Formats"
                     data={
@@ -133,7 +133,7 @@ export class DataCartGeneralTable extends Component {
                         ))
                     }
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     className="qa-DataPackGeneralTable-projection"
                     title="Projection"
                     data={

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackStatusTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackStatusTable.js
@@ -8,7 +8,7 @@ import Check from 'material-ui/svg-icons/navigation/check';
 import Edit from 'material-ui/svg-icons/image/edit';
 import Lock from 'material-ui/svg-icons/action/lock-outline';
 import moment from 'moment';
-import DataPackTableRow from './DataPackTableRow';
+import CustomTableRow from '../CustomTableRow';
 import DataPackShareDialog from '../DataPackShareDialog/DataPackShareDialog';
 
 export class DataPackStatusTable extends Component {
@@ -239,8 +239,8 @@ export class DataPackStatusTable extends Component {
         }
 
         return (
-            <div style={{ marginLeft: '-5px', marginTop: '-5px' }}>
-                <DataPackTableRow
+            <div>
+                <CustomTableRow
                     title="Export"
                     data={this.props.status}
                     titleStyle={{ backgroundColor: this.props.statusColor }}
@@ -249,11 +249,11 @@ export class DataPackStatusTable extends Component {
                         color: this.props.statusFontColor,
                     }}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     title="Expiration"
                     data={expirationData}
                 />
-                <DataPackTableRow
+                <CustomTableRow
                     title="Permissions"
                     dataStyle={{ flexWrap: 'wrap' }}
                     data={permissionData}

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportSummary.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportSummary.spec.js
@@ -6,19 +6,12 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import { Card, CardHeader, CardText } from 'material-ui/Card';
 
 import Map from 'ol/map';
-import View from 'ol/view';
-import interaction from 'ol/interaction';
 import VectorSource from 'ol/source/vector';
-import XYZ from 'ol/source/xyz';
 import GeoJSON from 'ol/format/geojson';
-import VectorLayer from 'ol/layer/vector';
-import Tile from 'ol/layer/tile';
-import ScaleLine from 'ol/control/scaleline';
-import Attribution from 'ol/control/attribution';
-import Zoom from 'ol/control/zoom';
 
 import { ExportSummary } from '../../components/CreateDataPack/ExportSummary';
 import CustomScrollbar from '../../components/CustomScrollbar';
+import CustomTableRow from '../../components/CustomTableRow';
 
 
 // this polyfills requestAnimationFrame in the test browser, required for ol3
@@ -84,23 +77,12 @@ describe('Export Summary Component', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         expect(wrapper.find(CustomScrollbar)).toHaveLength(1);
+        expect(wrapper.find(CustomTableRow)).toHaveLength(6);
         expect(wrapper.find('#form')).toHaveLength(1);
         expect(wrapper.find('#mainHeading').text()).toEqual('Preview and Run Export');
         expect(wrapper.find('#subHeading').text()).toEqual('Please make sure all the information below is correct.');
         expect(wrapper.find('#export-information-heading').text()).toEqual('Export Information');
-        expect(wrapper.find('#name').find('td').first().text()).toEqual('Name');
-        expect(wrapper.find('#name').find('td').last().text()).toEqual('name');
-        expect(wrapper.find('#description').find('td').first().text()).toEqual('Description');
-        expect(wrapper.find('#description').find('td').last().text()).toEqual('description');
-        expect(wrapper.find('#project').find('td').first().text()).toEqual('Project / Category');
-        expect(wrapper.find('#project').find('td').last().text()).toEqual('project');
-        expect(wrapper.find('#formats').find('td').first().text()).toEqual('File Formats');
-        expect(wrapper.find('#formats').find('td').last().text()).toEqual('Geopackage');
-        expect(wrapper.find('#layers').find('td').first().text()).toEqual('Data Sources');
-        expect(wrapper.find('#layers').find('td').last().text()).toEqual('one');
         expect(wrapper.find('#aoi-heading').text()).toEqual('Area of Interest (AOI)');
-        expect(wrapper.find('#aoi-area').find('td').first().text()).toEqual('Area');
-        expect(wrapper.find('#aoi-area').find('td').last().text()).toEqual('12 sq km');
         expect(wrapper.find('#aoi-map')).toHaveLength(1);
         expect(wrapper.find(Card)).toHaveLength(1);
         expect(wrapper.find(CardHeader)).toHaveLength(1);

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartInfoTable.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataCartInfoTable.spec.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { mount } from 'enzyme';
 import moment from 'moment';
-import DataPackTableRow from '../../components/StatusDownloadPage/DataPackTableRow';
+import CustomTableRow from '../../components/CustomTableRow';
 import DataCartInfoTable from '../../components/StatusDownloadPage/DataCartInfoTable';
 
 describe('DataCartInfoTable component', () => {
@@ -17,6 +17,6 @@ describe('DataCartInfoTable component', () => {
     const wrapper = mount(<DataCartInfoTable {...props} />);
 
     it('should render the 4 needed rows', () => {
-        expect(wrapper.find(DataPackTableRow)).toHaveLength(4);
+        expect(wrapper.find(CustomTableRow)).toHaveLength(4);
     });
 });

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackGeneralTable.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackGeneralTable.spec.js
@@ -3,7 +3,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import Info from 'material-ui/svg-icons/action/info';
-import DataPackTableRow from '../../components/StatusDownloadPage/DataPackTableRow';
+import CustomTableRow from '../../components/CustomTableRow';
 import BaseDialog from '../../components/Dialog/BaseDialog';
 import DataPackGeneralTable from '../../components/StatusDownloadPage/DataPackGeneralTable';
 import { DataPackDetails } from '../../components/StatusDownloadPage/DataPackDetails';
@@ -61,7 +61,7 @@ describe('DataPackGeneralTable component', () => {
     it('should render the basic components', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
-        expect(wrapper.find(DataPackTableRow)).toHaveLength(5);
+        expect(wrapper.find(CustomTableRow)).toHaveLength(5);
         expect(wrapper.find(BaseDialog)).toHaveLength(3);
     });
 

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackStatusTable.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackStatusTable.spec.js
@@ -5,7 +5,7 @@ import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import DatePicker from 'material-ui/DatePicker';
 import Edit from 'material-ui/svg-icons/image/edit';
-import DataPackTableRow from '../../components/StatusDownloadPage/DataPackTableRow';
+import CustomTableRow from '../../components/CustomTableRow';
 import DataPackShareDialog from '../../components/DataPackShareDialog/DataPackShareDialog';
 import DataPackStatusTable from '../../components/StatusDownloadPage/DataPackStatusTable';
 
@@ -46,7 +46,7 @@ describe('DataPackStatusTable component', () => {
     it('should render basic components', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
-        expect(wrapper.find(DataPackTableRow)).toHaveLength(3);
+        expect(wrapper.find(CustomTableRow)).toHaveLength(3);
         expect(wrapper.find(DatePicker)).toHaveLength(1);
         expect(wrapper.find(DropDownMenu)).toHaveLength(1);
     });


### PR DESCRIPTION
This PR adds the AOI area to the ExportInfo page.
It also moves the DataPackTableRow to CustomTableRow so its more accessable to the rest of the application. The <table> elements in ExportInfo and ExportSummary were replaced with the CustomTableRows (makeing use of standardized component and reduceing css/jsx needed).
![image](https://user-images.githubusercontent.com/16799449/39058545-26f37e36-448a-11e8-9720-b6987a756bbc.png)

***This was branched off of 427 so that should be merged before this one***