### PR TITLE
Error messages for feature selection on the admin page.

### DIFF
--- a/eventkit_cloud/jobs/admin.py
+++ b/eventkit_cloud/jobs/admin.py
@@ -131,10 +131,10 @@ class DataProviderForm(forms.ModelForm):
             if not config:
                 raise forms.ValidationError("Configuration is required for OSM data providers")
             from ..feature_selection.feature_selection import FeatureSelection
-            try:
-                FeatureSelection.example(config)
-            except AssertionError:
-                raise forms.ValidationError("Invalid configuration")
+            feature_selection = FeatureSelection(config)
+            feature_selection.valid
+            if feature_selection.errors:
+                raise forms.ValidationError("Invalid configuration: {0}".format(feature_selection.errors))
 
         return config
 


### PR DESCRIPTION
Currently feature selection does provide validation (thanks HOT) however it doesn't provide error message it simply reads `invalid configuration`.  This PR will add support for validation messages. 

To test open the OSM (Themes) data provider and alter a theme (table) to an invalid type by adding a hyphen, you should see an error message.

![image](https://user-images.githubusercontent.com/6437951/39704943-ebb6eb1a-51da-11e8-9a72-89968c2f3879.png)
