### PR TITLE
Max selection area backend check

### DIFF
--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -110,7 +110,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'test', 'formats': formats}],
             'export_providers': [{'name': 'test', 'level_from': 0, 'level_to': 1,
                                   'url': 'http://coolproviderurl.to',
@@ -211,7 +211,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'published': True,
@@ -238,7 +238,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'published': True,
@@ -303,7 +303,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'transform': '',
@@ -342,7 +342,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'transform': '',
@@ -393,7 +393,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': '',  # empty
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'formats': formats
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
@@ -410,7 +410,7 @@ class TestJobViewSet(APITestCase):
             'name': name,
             'description': 'Test description',
             'event': 'Test event',
-            'selection': bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}]
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
@@ -427,7 +427,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)'}]  # 'formats': formats}]# missing
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
@@ -441,7 +441,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': ''}]  # invalid
         }
         response = self.client.post(url, request_data, format='json')
@@ -456,7 +456,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([-3.9, 16.1, 7.0, 27.6]),
+            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
             'provider_tasks': [
                 {'provider': 'OpenStreetMap Data (Generic)', 'formats': ['broken-format-one', 'broken-format-two']}]
         }

--- a/eventkit_cloud/api/tests/test_views.py
+++ b/eventkit_cloud/api/tests/test_views.py
@@ -110,7 +110,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'test', 'formats': formats}],
             'export_providers': [{'name': 'test', 'level_from': 0, 'level_to': 1,
                                   'url': 'http://coolproviderurl.to',
@@ -211,7 +211,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'published': True,
@@ -238,7 +238,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'published': True,
@@ -303,7 +303,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'transform': '',
@@ -342,7 +342,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}],
             'preset': self.job.preset.id,
             'transform': '',
@@ -393,7 +393,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': '',  # empty
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
             'formats': formats
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
@@ -410,7 +410,7 @@ class TestJobViewSet(APITestCase):
             'name': name,
             'description': 'Test description',
             'event': 'Test event',
-            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': formats}]
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
@@ -420,14 +420,13 @@ class TestJobViewSet(APITestCase):
         self.assertEquals('ValidationError', response.data['errors'][0]['title'])
         self.assertEquals('name: Ensure this field has no more than 100 characters.', response.data['errors'][0]['detail'])
 
-
     def test_missing_format_param(self,):
         url = reverse('api:jobs-list')
         request_data = {
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection': bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection': bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)'}]  # 'formats': formats}]# missing
         }
         response = self.client.post(url, data=json.dumps(request_data), content_type='application/json; version=1.0')
@@ -441,7 +440,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [{'provider': 'OpenStreetMap Data (Generic)', 'formats': ''}]  # invalid
         }
         response = self.client.post(url, request_data, format='json')
@@ -456,7 +455,7 @@ class TestJobViewSet(APITestCase):
             'name': 'TestJob',
             'description': 'Test description',
             'event': 'Test Activation',
-            'selection':  bbox_to_geojson([[5, 16, 5.1, 16.1]]),
+            'selection':  bbox_to_geojson([5, 16, 5.1, 16.1]),
             'provider_tasks': [
                 {'provider': 'OpenStreetMap Data (Generic)', 'formats': ['broken-format-one', 'broken-format-two']}]
         }
@@ -529,7 +528,8 @@ class TestBBoxSearch(APITestCase):
         url = reverse('api:jobs-list')
         # create dummy user
         self.group, created = Group.objects.get_or_create(name='TestDefaultExportExtentGroup')
-        self.user = User.objects.create_user( username='demo', email='demo@demo.com', password='demo' )
+        self.user = User.objects.create_user(username='demo', email='demo@demo.com', password='demo',
+                                             is_superuser=True)
 
         # setup token authentication
         token = Token.objects.create(user=self.user)

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -561,19 +561,10 @@ def output_selection_geojson_task(self, result=None, task_uid=None, selection=No
     """
     result = result or {}
 
-    geojson_file = os.path.join(stage_dir,
-                                "{0}_selection.geojson".format(provider_slug))
+    geojson_file = os.path.join(stage_dir, "{0}_selection.geojson".format(provider_slug))
     if selection:
         # Test if json.
         json.loads(selection)
-
-        # Test against max AOI size
-        from ..jobs.models import DataProvider
-        max_selection = DataProvider.objects.get(slug=provider_slug).max_selection
-        aoi_area = gdalutils.get_area(selection)
-        logger.debug("Selected area is %s km^2; max for provider %s is %s", aoi_area, provider_slug, max_selection)
-        if 0 < max_selection < aoi_area:
-            raise Exception("AOI is too large for this provider")
 
         from audit_logging.file_logging import logging_open
         user_details = kwargs.get('user_details')

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -105,7 +105,7 @@ def is_raster(ds_path):
 
 def get_area(geojson):
     """
-    Given a GeoJSON string or object, return an approximation of its geodesic area in km².
+    Given a GeoJSON string or object, return an approximation of its geodesic area in kmÂ².
     The geometry must contain a single polygon with a single ring, no holes.
     Based on Chamberlain and Duquette's algorithm: https://trs.jpl.nasa.gov/bitstream/handle/2014/41271/07-0286.pdf
     :param geojson: GeoJSON selection area
@@ -119,16 +119,28 @@ def get_area(geojson):
     if isinstance(geojson, str):
         geojson = json.loads(geojson)
 
-    ring = geojson['coordinates'][0]
-    if len(ring) < 4:
-        return 0
+    if hasattr(geojson, 'geometry'):
+        geojson = geojson['geometry']
 
-    ring.append(ring[-2])  # convenient for circular indexing
+    geom_type = geojson['type'].lower()
+    if geom_type == 'polygon':
+        polys = [geojson['coordinates']]
+    elif geom_type == 'multipolygon':
+        polys = geojson['coordinates']
+    else:
+        return RuntimeError("Invalid geometry type: %s" % geom_type)
+
     a = 0
-    for i in range(len(ring) - 2):
-        a += (rad(ring[i+1][0]) - rad(ring[i-1][0])) * math.sin(rad(ring[i][1]))
-    result = abs(a * (earth_r**2) / 2)
-    return result
+    for poly in polys:
+        ring = poly[0]
+        if len(ring) < 4:
+            continue
+        ring.append(ring[-2])  # convenient for circular indexing
+        for i in range(len(ring) - 2):
+            a += (rad(ring[i+1][0]) - rad(ring[i-1][0])) * math.sin(rad(ring[i][1]))
+
+    area = abs(a * (earth_r**2) / 2)
+    return area
 
 
 def is_envelope(geojson_path):


### PR DESCRIPTION
Fix for ES-445.

This fix will compare the selection area of a submitted job against each of that job's selected providers' maximum areas, and if any are too large, will fail with an informative message, e.g.

![image](https://user-images.githubusercontent.com/5322068/39946135-02297d32-553b-11e8-9a9e-ea2322e61014.png)

Also, this branch adds proper support for checking the areas of multipolygon selections that actually have multiple polygons in them, not just one.