### PR TITLE
Added additional WCS support.

### DIFF
--- a/eventkit_cloud/settings/prod.py
+++ b/eventkit_cloud/settings/prod.py
@@ -348,7 +348,7 @@ LOGGING = {
     },
 }
 
-DISABLE_SSL_VERIFICATION = os.environ.get('DISABLE_SSL_VERIFICATION', False)
+DISABLE_SSL_VERIFICATION = True if 't' in os.environ.get('DISABLE_SSL_VERIFICATION').lower() else False
 
 LAND_DATA_URL = os.environ.get('LAND_DATA_URL', "http://data.openstreetmapdata.com/land-polygons-split-3857.zip")
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -679,12 +679,16 @@ def wcs_export_task(self, result=None, layer=None, config=None, run_uid=None, ta
     """
     Class defining export for WCS services
     """
+    from ..tasks.models import ExportTaskRecord
+
     result = result or {}
     out = os.path.join(stage_dir, '{0}.tif'.format(job_name))
+
+    task = ExportTaskRecord.objects.get(uid=task_uid)
     try:
-        wcs_conv = wcs.WCSConverter(out=out, bbox=bbox, service_url=service_url, name=name, layer=layer,
-                                    config=config, service_type=service_type, task_uid=task_uid, debug=True,
-                                    fmt="gtiff")
+        wcs_conv = wcs.WCSConverter(config=config, out=out, bbox=bbox, service_url=service_url, layer=layer, debug=True,
+                                    name=name, task_uid=task_uid, fmt="gtiff", slug=task.export_provider_task.slug,
+                                    user_details=user_details)
         wcs_conv.convert()
         result['result'] = out
         result['geotiff'] = out

--- a/eventkit_cloud/tasks/task_runners.py
+++ b/eventkit_cloud/tasks/task_runners.py
@@ -304,7 +304,8 @@ class ExportWCSTaskRunner(TaskRunner):
                                                     export_provider_task=export_provider_task, worker=worker,
                                                     display=getattr(service_task, "display", False))
 
-            task_chain = (service_task.s(stage_dir=stage_dir,
+            task_chain = (service_task.s(config=provider_task.provider.config,
+                                         stage_dir=stage_dir,
                                          job_name=job_name,
                                          task_uid=export_task.uid,
                                          name=provider_task.provider.slug,

--- a/eventkit_cloud/utils/gdalutils.py
+++ b/eventkit_cloud/utils/gdalutils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from osgeo import gdal, ogr
+from osgeo import gdal, ogr, osr
 import json
 import logging
 import math
@@ -303,3 +303,67 @@ def convert(dataset=None, fmt=None, task_uid=None):
         raise Exception("Conversion process failed with return code {0}".format(task_process.exitcode))
 
     return dataset
+
+
+def get_dimensions(bbox, scale):
+    """
+
+    :param bbox: A list [w, s, e, n].
+    :param scale: A scale in meters per pixel.
+    :return: A list [width, height] representing pixels
+    """
+    width = get_distance([bbox[0], bbox[1]], [bbox[2], bbox[1]])
+    height = get_distance([bbox[0], bbox[1]], [bbox[0], bbox[3]])
+    return [int(width/scale), int(height/scale)]
+
+
+def get_line(coordinates):
+    """
+
+    :param coordinates: A list representing a single coordinate in decimal degrees.
+        Example: [[W/E, N/S], [W/E, N/S]]
+    :return: AN OGR geometry point.
+    """
+    # This line will implicitly be in EPSG:4326 because that is what the geojson standard specifies.
+    geojson = json.dumps({"type": "LineString", "coordinates": coordinates})
+    return ogr.CreateGeometryFromJson(geojson)
+
+
+def get_distance(point_a, point_b):
+    """
+    Takes two points, and converts them to a line, converts the geometry to mercator and returns length in meters.
+    The geometry is converted to mercator because length is based on the SRS unit of measure (meters for mercator).
+    :param point_a: A list representing a single point [W/E, N/S].
+    :param point_b: A list representing a single point [W/E, N/S].
+    :return: Distance in meters.
+    """
+    line = get_line([point_a, point_b])
+    reproject_geometry(line, 4326, 3857)
+    return line.Length()
+
+
+def reproject_geometry(geometry, from_srs, to_srs):
+    """
+
+    :param geometry: Converts an ogr geometry from one spatial reference system to another
+    :param from_srs:
+    :param to_srs:
+    :return:
+    """
+    return geometry.Transform(get_transform(from_srs, to_srs))
+
+
+def get_transform(from_srs, to_srs):
+    """
+
+    :param from_srs: A spatial reference (EPSG) represented as an int (i.e. EPSG:4326 = 4326)
+    :param to_srs: A spatial reference (EPSG) represented as an int (i.e. EPSG:4326 = 4326)
+    :return: An osr coordinate transformation object.
+    """
+    source = osr.SpatialReference()
+    source.ImportFromEPSG(from_srs)
+
+    target = osr.SpatialReference()
+    target.ImportFromEPSG(to_srs)
+
+    return osr.CoordinateTransformation(source, target)

--- a/eventkit_cloud/utils/tests/test_wcs.py
+++ b/eventkit_cloud/utils/tests/test_wcs.py
@@ -50,15 +50,8 @@ class TestWCSConverter(TransactionTestCase):
         get_cred.return_value = ("testUser", "testPass")
         self.task_process.return_value = Mock(exitcode=0)
 
-        wcs_conv = WCSConverter(out=geotiff,
-                                bbox=bbox,
-                                service_url=service_url,
-                                layer=layer,
-                                debug=False,
-                                name=name,
-                                service_type=None,
-                                task_uid=self.task_uid,
-                                fmt="gtiff")
+        wcs_conv = WCSConverter(out=geotiff, bbox=bbox, service_url=service_url, layer=layer, debug=False, name=name,
+                                service_type=None, task_uid=self.task_uid, fmt="gtiff")
         out = wcs_conv.convert()
         self.task_process.assert_called_once_with(task_uid=self.task_uid)
         exists.assert_called_once_with(os.path.dirname(geotiff))
@@ -86,15 +79,8 @@ class TestWCSConverter(TransactionTestCase):
         exists.return_value = True
         self.task_process.return_value = Mock(exitcode=0)
 
-        wcs_conv = WCSConverter(out=geotiff,
-                                bbox=bbox,
-                                service_url=service_url,
-                                layer=layer,
-                                debug=False,
-                                name=name,
-                                service_type=None,
-                                task_uid=self.task_uid,
-                                fmt="gpkg")
+        wcs_conv = WCSConverter(out=geotiff, bbox=bbox, service_url=service_url, layer=layer, debug=False, name=name,
+                                service_type=None, task_uid=self.task_uid, fmt="gpkg")
         out = wcs_conv.convert()
         self.task_process.assert_called_once_with(task_uid=self.task_uid)
         exists.assert_called_once_with(os.path.dirname(geotiff))

--- a/eventkit_cloud/utils/wcs.py
+++ b/eventkit_cloud/utils/wcs.py
@@ -6,8 +6,10 @@ from string import Template
 import subprocess
 import tempfile
 from ..tasks.task_process import TaskProcess
-
+import yaml
 from ..utils import auth_requests
+from .gdalutils import get_dimensions
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -18,27 +20,25 @@ class WCSConverter(object):
     """
 
     def __init__(self, config=None, out=None, bbox=None, service_url=None, layer=None, debug=None, name=None,
-                 service_type=None, task_uid=None, fmt=None):
+                 task_uid=None, fmt=None, slug=None, user_details=None):
         """
         Initialize the WCStoGPKG utility.
-        :param config:
-        :param gpkg:
-        :param bbox:
-        :param service_url:
-        :param layer:
-        :param debug:
-        :param name:
-        :param service_type:
+        :param slug: An identifier slug for the provider task record.
+        :param config: Some yaml configuration to pass parameters to a WCS service.
+        :param bbox: A bounding box as a list [w,s,e,n]
+        :param service_url: The url to the WCS service.
+        :param layer: The specific coverage to request.
+        :param debug: Boolean to enable debugging.
+        :param name: A name for the service.
         :param task_uid:
         """
-        self.config = config
+        self.config = yaml.load(config) if config is not None else None
         self.out = out
         self.bbox = bbox
         self.service_url = service_url
         self.layer = layer
         self.debug = debug
         self.name = name
-        self.service_type = service_type
         self.task_uid = task_uid
         self.wcs_xml = Template(
             """<WCS_GDAL>
@@ -68,14 +68,10 @@ class WCSConverter(object):
         self.band_type = ""
         if self.format.lower() == "gpkg":
             self.band_type = "-ot byte"  # geopackage raster is limited to byte band type
+        self.slug = slug
+        self.user_details = user_details
 
-    def convert(self, ):
-        """
-        Download WCS data and convert to geopackage
-        """
-        if not os.path.exists(os.path.dirname(self.out)):
-            os.makedirs(os.path.dirname(self.out), 6600)
-
+    def get_coverage_with_gdal(self):
         # Get username and password from url params, if possible
         cred = auth_requests.get_cred(slug=self.name, url=self.service_url)
 
@@ -123,4 +119,51 @@ class WCSConverter(object):
 
         os.remove(self.wcs_xml_path)
 
+    def get_coverage_with_requests(self):
+        logger.info("Using admin configuration for the WCS request.")
+        service = self.config.get('service')
+        if not service:
+            raise Exception('A service key needs to be defined to include the scale of source in meters')
+        logger.info("Getting Dimensions...")
+        width, height = get_dimensions(self.bbox, int(service.get('scale')))
+        params = self.config.get('params')
+        params['width'] = str(width)
+        params['height'] = str(height)
+        params['service'] = 'WCS'
+        params['bbox'] = ','.join(map(str, self.bbox))
+        try:
+            req = auth_requests.get(self.service_url, params=params, slug=self.slug, stream=True,
+                                    verify=(not getattr(settings, 'DISABLE_SSL_VERIFICATION', False)))
+            logger.info("Getting the coverage: {0}".format(logger.error(req.url)))
+            try:
+                size = int(req.headers.get('content-length'))
+            except (ValueError, TypeError):
+                if req.content:
+                    size = len(req.content)
+                else:
+                    raise Exception("Overpass Query failed to return any data")
+            if not req:
+                logger.error(req.content)
+                raise Exception("WCS request for {0} failed.".format(self.name))
+            CHUNK = 1024 * 1024 * 2  # 2MB chunks
+            from audit_logging.file_logging import logging_open
+            with logging_open(self.out, 'wb', user_details=self.user_details) as fd:
+                for chunk in req.iter_content(CHUNK):
+                    fd.write(chunk)
+                    size += CHUNK
+        except Exception as e:
+            logger.error(e)
+            raise Exception("There was an error writing the file to disk.")
+
+    def convert(self, ):
+        """
+        Download WCS data and convert to geopackage
+        """
+        if not os.path.exists(os.path.dirname(self.out)):
+            os.makedirs(os.path.dirname(self.out), 6600)
+
+        if self.config:
+            self.get_coverage_with_requests()
+        else:
+            self.get_coverage_with_gdal()
         return self.out


### PR DESCRIPTION
This PR allows WCS providers to be configured by passing in a configurations via the admin console.  An example of a configuration would be.
```
service:
  scale: "50"
params:
  COVERAGE: '14'
  TRANSPARENT: true
  FORMAT: geotiff
  VERSION: '1.0.0'
  REQUEST: GetCoverage
  CRS: "EPSG:4326"
```
Where scale as a service parameter is a meters to pixel ratio (i.e. 50 meters per pixel) to generate a height and width given some bounding box.  

The params are the URL parameters for the request. 