### PR TITLE
Add background color to map in AOI selection

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -720,6 +720,7 @@ export class ExportAOI extends Component {
     render() {
         const mapStyle = {
             right: '0px',
+            backgroundColor: '#253447',
         };
 
         if (this.props.drawer === 'open' && window.innerWidth >= 1200) {

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -44,6 +44,7 @@ import {
     getDominantGeometry } from '../../utils/mapUtils';
 import { getSqKm } from '../../utils/generic';
 import ZoomLevelLabel from '../MapTools/ZoomLevelLabel';
+import background from '../../../images/topoBackground.jpg';
 
 export const WGS84 = 'EPSG:4326';
 export const WEB_MERCATOR = 'EPSG:3857';
@@ -720,7 +721,7 @@ export class ExportAOI extends Component {
     render() {
         const mapStyle = {
             right: '0px',
-            backgroundColor: '#253447',
+            backgroundImage: `url(${background})`,
         };
 
         if (this.props.drawer === 'open' && window.innerWidth >= 1200) {


### PR DESCRIPTION
This addresses ES-476: On larger monitors, search bar on map spans entire map.

The search bar wasn't actually spanning the whole map, it was just melding with the white map background above 90°N. Changing the background color from white to EventKit's dark desaturated blue (#253447) solves this.

![image](https://user-images.githubusercontent.com/5322068/40734600-e2a47f18-6406-11e8-8eb9-ecbcc228b15b.png)

Alternatively, #AAD3DC could work, to match the ocean color in the OSM tile basemap:

![image](https://user-images.githubusercontent.com/5322068/40735660-bd7f16a0-6409-11e8-97ca-9bfc3bb33a07.png)

Or the topo pattern background:

![image](https://user-images.githubusercontent.com/5322068/40737280-4750172c-640e-11e8-88bd-2da4c7f9d554.png)
