### PR TITLE
473 handle broken notifications

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,7 @@
         "no-console": "off",
         "import/no-named-as-default": "off",
         "import/prefer-default-export": "off",
-        "indent": [2, 4],
+        "indent": [2, 4, { "SwitchCase": 1 }],
         "linebreak-style": ["error", "windows"],
 
         "react/jsx-filename-extension": 0,

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationGridItem.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationGridItem.js
@@ -74,9 +74,9 @@ export class NotificationGridItem extends Component {
             >
                 {icon}
                 {message}
-                <div style={{flex: '1'}}></div>
+                <div style={{ flex: '1' }} />
                 <div
-                    className={'qa-NotificationGridItem-Date'}
+                    className="qa-NotificationGridItem-Date"
                     style={styles.date}
                 >
                     {moment(this.props.notification.timestamp).fromNow()}

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsTableItem.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsTableItem.js
@@ -116,14 +116,14 @@ export class NotificationsTableItem extends React.Component {
                     <Checkbox
                         checked={this.props.isSelected}
                         onCheck={(e, isChecked) => this.props.setSelected(this.props.notification, isChecked)}
-                        disableTouchRipple={true}
+                        disableTouchRipple
                     />
                 </TableRowColumn>
                 <TableRowColumn
                     className="qa-NotificationsTableItem-Content"
                     style={styles.contentRowColumn}
                 >
-                    <div style={{display: 'flex', alignItems: 'center', width: '100%'}}>
+                    <div style={{ display: 'flex', alignItems: 'center', width: '100%' }}>
                         {icon}
                         {message}
                     </div>
@@ -153,7 +153,7 @@ export class NotificationsTableItem extends React.Component {
                                             labelStyle={styles.optionButtonLabel}
                                             icon={<OpenInNewIcon style={styles.optionButtonLabel} />}
                                             hoverColor="rgba(0, 0, 0, 0)"
-                                            disableTouchRipple={true}
+                                            disableTouchRipple
                                             onClick={this.handleView}
                                         />
                                         :
@@ -167,7 +167,7 @@ export class NotificationsTableItem extends React.Component {
                                             labelStyle={styles.optionButtonLabel}
                                             icon={<FlagIcon style={styles.optionButtonLabel} />}
                                             hoverColor="rgba(0, 0, 0, 0)"
-                                            disableTouchRipple={true}
+                                            disableTouchRipple
                                             onClick={this.handleMarkAsRead}
                                         />
                                         :
@@ -176,7 +176,7 @@ export class NotificationsTableItem extends React.Component {
                                             labelStyle={styles.optionButtonLabel}
                                             icon={<FlagIcon style={styles.optionButtonLabel} />}
                                             hoverColor="rgba(0, 0, 0, 0)"
-                                            disableTouchRipple={true}
+                                            disableTouchRipple
                                             onClick={this.handleMarkAsUnread}
                                         />
                                     }
@@ -187,14 +187,14 @@ export class NotificationsTableItem extends React.Component {
                                         labelStyle={styles.optionButtonLabel}
                                         icon={<CloseIcon style={styles.optionButtonLabel} />}
                                         hoverColor="rgba(0, 0, 0, 0)"
-                                        disableTouchRipple={true}
+                                        disableTouchRipple
                                         onClick={this.handleRemove}
                                     />
                                 </div>
                             </div>
                             :
                             <NotificationMenu
-                                className={'qa-NotificationsTableItem-NotificationMenu'}
+                                className="qa-NotificationsTableItem-NotificationMenu"
                                 notification={this.props.notification}
                                 router={this.props.router}
                                 onMarkAsRead={this.props.onMarkAsRead}
@@ -222,17 +222,17 @@ NotificationsTableItem.propTypes = {
 };
 
 NotificationsTableItem.defaultProps = {
-    onMarkAsRead: () => { return true; },
-    onMarkAsUnread: () => { return true; },
-    onRemove: () => { return true; },
-    onView: () => { return true; },
+    onMarkAsRead: () => true,
+    onMarkAsUnread: () => true,
+    onRemove: () => true,
+    onView: () => true,
 };
 
 function mapDispatchToProps(dispatch) {
     return {
-        markNotificationsAsRead: (notifications) => dispatch(markNotificationsAsRead(notifications)),
-        markNotificationsAsUnread: (notifications) => dispatch(markNotificationsAsUnread(notifications)),
-        removeNotifications: (notifications) => dispatch(removeNotifications(notifications)),
+        markNotificationsAsRead: notifications => dispatch(markNotificationsAsRead(notifications)),
+        markNotificationsAsUnread: notifications => dispatch(markNotificationsAsUnread(notifications)),
+        removeNotifications: notifications => dispatch(removeNotifications(notifications)),
     };
 }
 

--- a/eventkit_cloud/ui/static/ui/app/tests/utils/notificationUtils.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/utils/notificationUtils.spec.js
@@ -165,6 +165,7 @@ describe('notificationUtils', () => {
         const notification = {
             id: '1',
             verb: 'added_to_group',
+            actor: {},
             action_object: {
                 details: group,
             },
@@ -187,6 +188,7 @@ describe('notificationUtils', () => {
         const notification = {
             id: '1',
             verb: 'removed_from_group',
+            actor: {},
             action_object: {
                 details: group,
             },
@@ -209,6 +211,7 @@ describe('notificationUtils', () => {
         const notification = {
             id: '1',
             verb: 'set_as_group_admin',
+            actor: {},
             action_object: {
                 details: group,
             },
@@ -231,6 +234,7 @@ describe('notificationUtils', () => {
         const notification = {
             id: '1',
             verb: 'removed_as_group_admin',
+            actor: {},
             action_object: {
                 details: group,
             },
@@ -249,9 +253,23 @@ describe('notificationUtils', () => {
         expect(viewPath).toBe('/groups');
     });
 
+    it('should handle notifications with no details', () => {
+        const notification = {
+            id: '1',
+            actor: {},
+            action_object: {},
+            verb: 'removed_as_group_admin',
+        };
+
+        const ret = utils.getNotificationMessage({ notification });
+        expect(ret[0].key).toEqual('1-error');
+    });
+
     it('should correctly handle unsupported notification verbs', () => {
         const notification = {
             id: '1',
+            actor: {},
+            action_object: { details: 'something' },
             verb: 'some_unsupported_verb',
         };
 

--- a/eventkit_cloud/ui/static/ui/app/utils/notificationUtils.js
+++ b/eventkit_cloud/ui/static/ui/app/utils/notificationUtils.js
@@ -68,7 +68,7 @@ export function getNotificationMessage({
                 style={{ ...styles.text, color: '#CE4427', whiteSpace: 'normal' }}
                 className="qa-NotificationMessage-error"
             >
-                Uh oh! Sorry, this notification&apos;s details are no longer available
+                Uh oh! Sorry, this notification&apos;s details are no longer available.
             </span>,
         ];
     }

--- a/eventkit_cloud/ui/static/ui/app/utils/notificationUtils.js
+++ b/eventkit_cloud/ui/static/ui/app/utils/notificationUtils.js
@@ -22,7 +22,12 @@ const verbs = {
 // NOTE: This should ideally be a NotificationMessage component, but we need to return the bare elements without
 // a wrapper to solve the middle text truncation problem. With React 16 we'll be able to do this from a component
 // by using fragments (https://reactjs.org/docs/fragments.html).
-export function getNotificationMessage({ notification, textStyle = {}, linkStyle = {}, onLinkClick = () => { return true; } }) {
+export function getNotificationMessage({
+    notification,
+    textStyle = {},
+    linkStyle = {},
+    onLinkClick = () => (true),
+}) {
     let styles = {
         text: {
             ...textStyle,
@@ -46,7 +51,7 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
             fontWeight: 'bold',
             overflow: 'hidden',
             textOverflow: 'ellipsis',
-        }
+        },
     };
 
     const handleLinkClick = (e) => {
@@ -56,12 +61,24 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
     };
 
     const verb = notification.verb.toLowerCase();
+    if (!notification.actor.details && !notification.action_object.details) {
+        return [
+            <span
+                key={`${notification.id}-error`}
+                style={{ ...styles.text, color: '#CE4427', whiteSpace: 'normal' }}
+                className="qa-NotificationMessage-error"
+            >
+                Uh oh! Sorry, this notification&apos;s details are no longer available
+            </span>,
+        ];
+    }
+
     switch (verb) {
         case verbs.runStarted:
             return [
                 <Link
                     key={`${notification.id}-Link`}
-                    className={'qa-NotificationMessage-Link'}
+                    className="qa-NotificationMessage-Link"
                     to={`/status/${notification.actor.details.job.uid}`}
                     href={`/status/${notification.actor.details.job.uid}`}
                     style={styles.link}
@@ -72,17 +89,17 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
                 </Link>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     &nbsp;has started processing.
-                </span>
+                </span>,
             ];
         case verbs.runCanceled:
             return [
                 <Link
                     key={`${notification.id}-Link`}
-                    className={'qa-NotificationMessage-Link'}
+                    className="qa-NotificationMessage-Link"
                     to={`/status/${notification.actor.details.job.uid}`}
                     href={`/status/${notification.actor.details.job.uid}`}
                     style={styles.link}
@@ -93,17 +110,17 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
                 </Link>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     &nbsp;has been canceled.
-                </span>
+                </span>,
             ];
         case verbs.runCompleted:
             return [
                 <Link
                     key={`${notification.id}-Link`}
-                    className={'qa-NotificationMessage-Link'}
+                    className="qa-NotificationMessage-Link"
                     to={`/status/${notification.actor.details.job.uid}`}
                     href={`/status/${notification.actor.details.job.uid}`}
                     style={styles.link}
@@ -114,17 +131,17 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
                 </Link>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     &nbsp;is complete.
-                </span>
+                </span>,
             ];
         case verbs.runFailed:
             return [
                 <Link
                     key={`${notification.id}-Link`}
-                    className={'qa-NotificationMessage-Link'}
+                    className="qa-NotificationMessage-Link"
                     to={`/status/${notification.actor.details.job.uid}`}
                     href={`/status/${notification.actor.details.job.uid}`}
                     style={styles.link}
@@ -135,17 +152,17 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
                 </Link>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     &nbsp;failed to complete.
-                </span>
+                </span>,
             ];
         case verbs.runDeleted:
             return [
                 <Link
                     key={`${notification.id}-Link`}
-                    className={'qa-NotificationMessage-Link'}
+                    className="qa-NotificationMessage-Link"
                     to={`/status/${notification.actor.details.job.uid}`}
                     href={`/status/${notification.actor.details.job.uid}`}
                     style={styles.link}
@@ -156,24 +173,24 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
                 </Link>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     &nbsp;has been deleted.
-                </span>
+                </span>,
             ];
         case verbs.addedToGroup:
             return [
                 <span
                     key={`${notification.id}-span0`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     {"You've been added to"}&nbsp;
                 </span>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.name}
                     title={notification.action_object.details.name}
                 >
@@ -184,14 +201,14 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
             return [
                 <span
                     key={`${notification.id}-span0`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     {"You've been removed from"}&nbsp;
                 </span>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.name}
                     title={notification.action_object.details.name}
                 >
@@ -202,14 +219,14 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
             return [
                 <span
                     key={`${notification.id}-span0`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     {"You've been set as an admin of"}&nbsp;
                 </span>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.name}
                     title={notification.action_object.details.name}
                 >
@@ -220,14 +237,14 @@ export function getNotificationMessage({ notification, textStyle = {}, linkStyle
             return [
                 <span
                     key={`${notification.id}-span0`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.text}
                 >
                     {"You've been removed as an admin of"}&nbsp;
                 </span>,
                 <span
                     key={`${notification.id}-span1`}
-                    className={'qa-NotificationMessage-Text'}
+                    className="qa-NotificationMessage-Text"
                     style={styles.name}
                     title={notification.action_object.details.name}
                 >
@@ -254,20 +271,20 @@ export function getNotificationIcon({ notification, iconStyle }) {
         case verbs.runStarted:
             return (
                 <InfoIcon
-                    className={'qa-NotificationIcon'}
+                    className="qa-NotificationIcon"
                     style={{
                         ...styles.icon,
-                        fill: '#1F2738'
+                        fill: '#1F2738',
                     }}
                 />
             );
         case verbs.runCompleted:
             return (
                 <CheckCircleIcon
-                    className={'qa-NotificationIcon'}
+                    className="qa-NotificationIcon"
                     style={{
                         ...styles.icon,
-                        fill: '#55BA63'
+                        fill: '#55BA63',
                     }}
                 />
             );
@@ -275,10 +292,10 @@ export function getNotificationIcon({ notification, iconStyle }) {
         case verbs.setAsGroupAdmin:
             return (
                 <AddCircleIcon
-                    className={'qa-NotificationIcon'}
+                    className="qa-NotificationIcon"
                     style={{
                         ...styles.icon,
-                        fill: '#55BA63'
+                        fill: '#55BA63',
                     }}
                 />
             );
@@ -287,30 +304,30 @@ export function getNotificationIcon({ notification, iconStyle }) {
         case verbs.removedAsGroupAdmin:
             return (
                 <RemoveCircleIcon
-                    className={'qa-NotificationIcon'}
+                    className="qa-NotificationIcon"
                     style={{
                         ...styles.icon,
-                        fill: '#CE4427'
+                        fill: '#CE4427',
                     }}
                 />
             );
         case verbs.runCanceled:
             return (
                 <WarningIcon
-                    className={'qa-NotificationIcon'}
+                    className="qa-NotificationIcon"
                     style={{
                         ...styles.icon,
-                        fill: '#F4D225'
+                        fill: '#F4D225',
                     }}
                 />
             );
         case verbs.runFailed:
             return (
                 <ErrorIcon
-                    className={'qa-NotificationIcon'}
+                    className="qa-NotificationIcon"
                     style={{
                         ...styles.icon,
-                        fill: '#CE4427'
+                        fill: '#CE4427',
                     }}
                 />
             );
@@ -327,6 +344,7 @@ export function getNotificationViewPath(notification) {
         case verbs.runCompleted:
         case verbs.runDeleted:
         case verbs.runFailed:
+            if (!notification.actor.details) return '';
             return `/status/${notification.actor.details.job.uid}`;
         case verbs.addedToGroup:
         case verbs.removedFromGroup:


### PR DESCRIPTION
This PR adds a check for missing detail data in the notifications. If there is no data then an error message will be shown instead.
![image](https://user-images.githubusercontent.com/16799449/40744909-0141aa96-6424-11e8-82ae-0eebcdc849ae.png)
