### PR TITLE
Fix zip download button

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackDetails.js
@@ -24,11 +24,11 @@ export class DataPackDetails extends Component {
     }
 
     getCloudDownloadIcon() {
-        if (this.props.zipFileProp === null) {
+        if (!this.props.zipFileProp) {
             return (
                 <CloudDownload
                     className="qa-DataPackDetails-CloudDownload-disabled"
-                    style={{ fill: 'gray', verticalAlign: 'middle' }}
+                    style={{ fill: 'grey', verticalAlign: 'middle' }}
                 />
             );
         }
@@ -65,10 +65,10 @@ export class DataPackDetails extends Component {
     }
 
     isZipFileCompleted() {
-        if (this.props.zipFileProp === null) {
-            return true;
+        if (!this.props.zipFileProp) {
+            return false;
         }
-        return false;
+        return true;
     }
 
     render() {
@@ -124,19 +124,18 @@ export class DataPackDetails extends Component {
                                 className="qa-DataPackDetails-TableHeaderColumn-zipButton"
                                 style={styles.download}
                             >
-                                <a href={this.props.zipFileProp}>
-                                    <RaisedButton
-                                        id="CompleteDownload"
-                                        className="qa-DataPackDetails-RaisedButton-zipButton"
-                                        backgroundColor="rgba(179,205,224,0.5)"
-                                        disabled={this.isZipFileCompleted()}
-                                        disableTouchRipple
-                                        labelColor="#4598bf"
-                                        labelStyle={{ fontWeight: 'bold', fontSize: textFontSize }}
-                                        label={this.props.zipFileProp ? 'DOWNLOAD DATAPACK (.ZIP)' : 'CREATING DATAPACK ZIP'}
-                                        icon={this.getCloudDownloadIcon()}
-                                    />
-                                </a>
+                                <RaisedButton
+                                    id="CompleteDownload"
+                                    href={this.props.zipFileProp}
+                                    className="qa-DataPackDetails-RaisedButton-zipButton"
+                                    backgroundColor="rgba(179,205,224,0.5)"
+                                    disabled={!this.isZipFileCompleted()}
+                                    disableTouchRipple
+                                    labelColor="#4598bf"
+                                    labelStyle={{ fontWeight: 'bold', fontSize: textFontSize }}
+                                    label={this.props.zipFileProp ? 'DOWNLOAD DATAPACK (.ZIP)' : 'CREATING DATAPACK ZIP'}
+                                    icon={this.getCloudDownloadIcon()}
+                                />
                             </TableHeaderColumn>
                             <TableHeaderColumn
                                 className="qa-DataPackDetails-TableHeaderColumn-fileSize"

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackDetails.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackDetails.spec.js
@@ -105,12 +105,12 @@ describe('DataPackDetails component', () => {
         const zipSpy = new sinon.spy(DataPackDetails.prototype, 'isZipFileCompleted');
         props.zipFileProp = null;
         wrapper.instance().isZipFileCompleted();
-        expect(wrapper.instance().isZipFileCompleted()).toEqual(true);
+        expect(wrapper.instance().isZipFileCompleted()).toEqual(false);
         let nextProps = {...props};
         nextProps.zipFileProp = 'TESTING.zip';
         wrapper.setProps(nextProps);
         wrapper.instance().isZipFileCompleted();
-        expect(wrapper.instance().isZipFileCompleted()).toEqual(false);
+        expect(wrapper.instance().isZipFileCompleted()).toEqual(true);
     });
 
     it('getCloudDownloadIcon should be called with correct data', () => {
@@ -119,7 +119,7 @@ describe('DataPackDetails component', () => {
         const wrapper = getWrapper(props);
         props.zipFileProp = null;
         wrapper.instance().getCloudDownloadIcon();
-        expect(wrapper.instance().getCloudDownloadIcon()).toEqual(<CloudDownload className={'qa-DataPackDetails-CloudDownload-disabled'} style={{fill:'gray', verticalAlign: 'middle'}}/>);
+        expect(wrapper.instance().getCloudDownloadIcon()).toEqual(<CloudDownload className={'qa-DataPackDetails-CloudDownload-disabled'} style={{fill:'grey', verticalAlign: 'middle'}}/>);
         let nextProps = {...props};
         nextProps.zipFileProp = 'TESTING.zip';
         wrapper.setProps(nextProps);


### PR DESCRIPTION
This PR fixes the Zip File download button. The button should now be properly disabled when the DataPack is still running.