### PR TITLE
fix bug that breaks view switching

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
@@ -695,9 +695,9 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
     return {
-        getRuns: (args) => {
-            dispatch(getRuns(args));
-        },
+        getRuns: args => (
+            dispatch(getRuns(args))
+        ),
         deleteRuns: (uid) => {
             dispatch(deleteRuns(uid));
         },


### PR DESCRIPTION
This fixes a bug with view switching in the DataPackPage. If you select the list view and sort by permissions or some other sort type not available in the other views, when you try to switch view it breaks the first time but works the second. This is because the axios promise was not being returned by the props.getRuns wrapper. Now when switching views there should be no issues.