### PR TITLE
Change link in My DataPacks "no data" message to "Create DataPack".

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardPage.js
@@ -509,11 +509,11 @@ export class DashboardPage extends React.Component {
                                     <Paper style={styles.noData}>
                                         {"You don't have any DataPacks."}&nbsp;
                                         <Link
-                                            to="/exports"
-                                            href="/exports"
+                                            to="/create"
+                                            href="/create"
                                             style={styles.link}
                                         >
-                                            View DataPack Library
+                                            Create DataPack
                                         </Link>
                                     </Paper>
                                 }


### PR DESCRIPTION
Changed link from "View DataPack Library" to "Create DataPack" at Liz's request. I think it makes more sense this way.

<img width="1038" alt="screenshot at jun 25 19-01-09" src="https://user-images.githubusercontent.com/3220897/41884859-2f713cd4-78aa-11e8-8048-f2b0c05102ad.png">
