### PR TITLE
More clearly indicate disabled dot tabs in Dashboard sections.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DashboardPage/DashboardSection.js
@@ -92,6 +92,7 @@ export class DashboardSection extends React.Component {
                 ...styles.tabButton,
                 backgroundColor: 'lightgray',
                 border: '3px solid gray',
+                opacity: '0.5',
             },
         };
 


### PR DESCRIPTION
People had mentioned that the disabled dots still looked clickable, so I dropped them to half opacity.

<img width="1039" alt="screenshot at jun 25 19-16-16" src="https://user-images.githubusercontent.com/3220897/41885328-5aba2264-78ac-11e8-8096-c80d9f796594.png">
