### PR TITLE
Fix issue where AOI menu position can appear glitchy on small screens.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/AoiInfobar.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/AoiInfobar.js
@@ -230,8 +230,8 @@ export class AoiInfobar extends Component {
                             <MoreVertIcon />
                         </IconButton>
                     }
-                    anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
-                    targetOrigin={{ horizontal: 'left', vertical: 'top' }}
+                    anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
+                    targetOrigin={{ horizontal: 'right', vertical: 'top' }}
                 >
                     <MenuItem
                         primaryText="ZOOM TO"


### PR DESCRIPTION
This occurs on screen sizes small enough where the menu doesn't have enough room to open from the left. I just made it open from the right across all screen sizes since I think it looks fine that way.

Before:
![screen recording 2018-06-25 at 09 29 pm](https://user-images.githubusercontent.com/3220897/41889437-8b45cb64-78bf-11e8-9cb3-282ff3968b2c.gif)

After:
![screen recording 2018-06-25 at 09 31 pm](https://user-images.githubusercontent.com/3220897/41889444-8fd39422-78bf-11e8-95ee-312d71cb6cf9.gif)
