### PR TITLE
Fix canceling data source.

### DIFF
--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -1133,12 +1133,12 @@ class DataProviderTaskViewSet(viewsets.ModelViewSet):
         * return: Returns {'success': True} on success. If the user did not have the correct rights (if not superuser, they must be asking for one of their own export provider tasks), then 403 forbidden will be returned.
         """
 
-        export_provider_task = DataProviderTaskRecord.objects.get(uid=uid)
+        data_provider_task_record = DataProviderTaskRecord.objects.get(uid=uid)
 
-        if export_provider_task.run.user != request.user and not request.user.is_superuser:
+        if data_provider_task_record.run.user != request.user and not request.user.is_superuser:
             return Response({'success': False}, status=status.HTTP_403_FORBIDDEN)
 
-        cancel_export_provider_task.run(export_provider_task_uid=uid, canceling_username=request.user.username)
+        cancel_export_provider_task.run(data_provider_task_uid=data_provider_task_record.uid, canceling_username=request.user.username)
         return Response({'success': True}, status=status.HTTP_200_OK)
 
     def list(self, request, *args, **kwargs):

--- a/eventkit_cloud/tasks/exceptions.py
+++ b/eventkit_cloud/tasks/exceptions.py
@@ -1,13 +1,12 @@
 class CancelException(Exception):
     """Used to indicate when a user calls for cancellation."""
 
-    def __init__(self, message=None, task_name=None, user_name=None, filename=None, *args, **kwargs):
+    def __init__(self, message=None, task_name=None, user_name="system", filename=None, *args, **kwargs):
         """
 
         :param message: A non-default message
         :param task_uid: Task_uid to look up user and task name.
         """
-        from .models import ExportTaskRecord
         self.message = message  # without this you may get DeprecationWarning
         self.filename = filename
         if not self.message:
@@ -24,7 +23,6 @@ class DeleteException(Exception):
         :param message: A non-default message
         :param task_uid: Task_uid to look up user and task name.
         """
-        from .models import ExportTaskRecord
         self.message = message  # without this you may get DeprecationWarning
         self.filename = filename
         if not self.message:

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -17,7 +17,6 @@ from django.contrib.gis.geos import Polygon
 from django.core.cache import caches
 from django.core.mail import EmailMultiAlternatives
 from django.db import DatabaseError, transaction
-from django.db.models import Q
 from django.template.loader import get_template, render_to_string
 from django.utils import timezone
 from celery import signature
@@ -38,7 +37,7 @@ from ..core.helpers import sendnotification, NotificationVerb, NotificationLevel
 
 from .exceptions import CancelException, DeleteException
 from .helpers import normalize_name, get_archive_data_path, get_run_download_url, get_download_filename, get_run_staging_dir, \
-    get_provider_staging_dir, get_run_download_dir, Directory, default_format_time
+    get_provider_staging_dir, get_run_download_dir, Directory, default_format_time, progressive_kill
 
 BLACKLISTED_ZIP_EXTS = ['.ini', '.om5', '.osm', '.lck', '.pyc']
 
@@ -185,7 +184,7 @@ def make_file_downloadable(filepath, run_uid, provider_slug='', skip_copy=False,
 
 
 # ExportTaskRecord abstract base class and subclasses.
-class ExportTask(LockingTask):
+class ExportTask(UserDetailsBase):
     """
     Abstract base class for export tasks.
     """
@@ -207,7 +206,8 @@ class ExportTask(LockingTask):
                 task_state_result = None
             self.update_task_state(result=task_state_result, task_uid=task_uid)
 
-            retval = super(ExportTask, self).__call__(*args, **kwargs)
+            if not TaskStates.CANCELED.value in [task.status, task.export_provider_task.status]:
+                retval = super(ExportTask, self).__call__(*args, **kwargs)
 
             """
             Update the successfully completed task as follows:
@@ -228,7 +228,10 @@ class ExportTask(LockingTask):
             finished = timezone.now()
             if TaskStates.CANCELED.value in [task.status, task.export_provider_task.status]:
                 logging.info('Task reported on success but was previously canceled ', format(task_uid))
-                raise CancelException(task_name=task.export_provider_task.name, user_name=task.cancel_user.username)
+                username = None
+                if task.cancel_user:
+                    username = task.cancel_user.username
+                raise CancelException(task_name=task.export_provider_task.name, user_name=username)
 
             task.finished_at = finished
             task.progress = 100
@@ -247,8 +250,6 @@ class ExportTask(LockingTask):
                                                       finished,
                                                       ext,
                                                       additional_descriptors=provider_slug)
-
-            export_run = ExportRun.objects.get(uid=run_uid)
             # construct the download url
             skip_copy = (task.name == 'OverpassQuery')
             download_url = make_file_downloadable(
@@ -310,7 +311,7 @@ class ExportTask(LockingTask):
             logger.debug('Task name: {0} failed, {1}'.format(self.name, einfo))
             if self.abort_on_error:
                 export_provider_task = DataProviderTaskRecord.objects.get(tasks__uid=task_id)
-                cancel_synchronous_task_chain(export_provider_task_uid=export_provider_task.uid)
+                cancel_synchronous_task_chain(data_provider_task_uid=export_provider_task.uid)
                 run = export_provider_task.run
                 stage_dir = kwargs['stage_dir']
                 export_task_error_handler(
@@ -332,6 +333,8 @@ class ExportTask(LockingTask):
         try:
             task = ExportTaskRecord.objects.get(uid=task_uid)
             celery_uid = self.request.id
+            if not celery_uid:
+                raise Exception("Failed to save celery_UID")
             task.celery_uid = celery_uid
             task.save()
             result = parse_result(result, 'status') or []
@@ -340,7 +343,8 @@ class ExportTask(LockingTask):
                 task.status = TaskStates.CANCELED.value
                 task.save()
                 raise CancelException(task_name=task.export_provider_task.name)
-            task.pid = os.getpid()
+            # The parent ID is actually the process running in celery.
+            task.pid = os.getppid()
             task.status = task_status
             task.export_provider_task.status = TaskStates.RUNNING.value
             task.started_at = started
@@ -627,7 +631,7 @@ def geotiff_export_task(self, result=None, run_uid=None, task_uid=None, stage_di
     return result
 
 
-@app.task(name='Clip Export', bind=True, base=LockingTask)
+@app.task(name='Clip Export', bind=True, base=UserDetailsBase)
 def clip_export_task(self, result=None, run_uid=None, task_uid=None, stage_dir=None, job_name=None, user_details=None,
                      *args, **kwargs):
     """
@@ -881,7 +885,7 @@ def pick_up_run_task(self, result=None, run_uid=None, user_details=None, *args, 
 
 
 # This could be improved by using Redis or Memcached to help manage state.
-@app.task(name='Wait For Providers', base=LockingTask)
+@app.task(name='Wait For Providers', base=UserDetailsBase)
 def wait_for_providers_task(result=None, apply_args=None, run_uid=None, callback_task=None, *args, **kwargs):
     from .models import ExportRun
 
@@ -899,7 +903,7 @@ def wait_for_providers_task(result=None, apply_args=None, run_uid=None, callback
         raise Exception("A run could not be found for uid {0}".format(run_uid))
 
 
-class FinalizeRunHookTask(LockingTask):
+class FinalizeRunHookTask(UserDetailsBase):
     """ Base for tasks which execute after all export provider tasks have completed, but before finalize_run_task.
         - Ensures the task state is recorded when the task is started and after it has completed.
         - Combines new_zip_filepaths list from the previous FinalizeRunHookTask in a chain with the new
@@ -1108,11 +1112,12 @@ def finalize_export_provider_task(result=None, export_provider_task_uid=None,
     with transaction.atomic():
 
         export_provider_task = DataProviderTaskRecord.objects.get(uid=export_provider_task_uid)
-        if TaskStates[result_status] != TaskStates.SUCCESS:
+        if TaskStates[result_status] == TaskStates.CANCELED:
+            export_provider_task.status = TaskStates.CANCELED.value
+        elif TaskStates[result_status] != TaskStates.SUCCESS:
             export_provider_task.status = TaskStates.INCOMPLETE.value
         else:
             export_provider_task.status = TaskStates.COMPLETED.value
-
         export_provider_task.finished_at = timezone.now()
         export_provider_task.save()
 
@@ -1232,7 +1237,7 @@ def zip_file_task(include_files, run_uid=None, file_name=None, adhoc=False, stat
     return result
 
 
-class FinalizeRunBase(LockingTask):
+class FinalizeRunBase(UserDetailsBase):
     name = 'Finalize Export Run'
 
     def run(self, result=None, run_uid=None, stage_dir=None):
@@ -1421,10 +1426,11 @@ def export_task_error_handler(self, result=None, run_uid=None, task_id=None, sta
     return result
 
 
-def cancel_synchronous_task_chain(export_provider_task_uid=None):
+def cancel_synchronous_task_chain(data_provider_task_uid=None):
     from ..tasks.models import DataProviderTaskRecord
-    export_provider_task = DataProviderTaskRecord.objects.filter(uid=export_provider_task_uid).first()
-    for export_task in export_provider_task.tasks.all():
+
+    data_provider_task_record = DataProviderTaskRecord.objects.get(uid=data_provider_task_uid)
+    for export_task in data_provider_task_record.tasks.all():
         if TaskStates[export_task.status] == TaskStates.PENDING.value:
             export_task.status = TaskStates.CANCELED.value
             export_task.save()
@@ -1435,8 +1441,8 @@ def cancel_synchronous_task_chain(export_provider_task_uid=None):
                 routing_key="{0}.cancel".format(export_task.worker))
 
 
-@app.task(name='Cancel Export Provider Task', base=LockingTask)
-def cancel_export_provider_task(result=None, export_provider_task_uid=None, canceling_username=None, delete=False,
+@app.task(name='Cancel Export Provider Task', base=UserDetailsBase)
+def cancel_export_provider_task(result=None, data_provider_task_uid=None, canceling_username=None, delete=False,
                                 error=False, *args, **kwargs):
     """
     Cancels an DataProviderTaskRecord and terminates each subtasks execution.
@@ -1452,18 +1458,13 @@ def cancel_export_provider_task(result=None, export_provider_task_uid=None, canc
     from django.contrib.auth.models import User
 
     result = result or {}
+    data_provider_task_record = DataProviderTaskRecord.objects.get(uid=data_provider_task_uid)
+    canceling_user = User.objects.get(username=canceling_username)
 
-    export_provider_task = DataProviderTaskRecord.objects.filter(uid=export_provider_task_uid).first()
-    canceling_user = User.objects.filter(username=canceling_username).first()
-
-    if not export_provider_task:
-        result['result'] = False
-        return result
-
-    export_tasks = export_provider_task.tasks.all()
+    export_tasks = data_provider_task_record.tasks.all()
 
     # Loop through both the tasks in the DataProviderTaskRecord model, as well as the Task Chain in celery
-    for export_task in export_tasks.filter(~Q(status=TaskStates.CANCELED.value) | ~Q(status=TaskStates.FAILED.value)):
+    for export_task in export_tasks.all():
         if delete:
             exception_class = DeleteException
         else:
@@ -1476,7 +1477,7 @@ def cancel_export_provider_task(result=None, export_provider_task_uid=None, canc
         # This part is to populate the UI with the cancel message.  If a different mechanism is incorporated
         # to pass task information to the users, then it may make sense to replace this.
         try:
-            raise exception_class(task_name=export_provider_task.name, user_name=canceling_user)
+            raise exception_class(task_name=data_provider_task_record.name, user_name=canceling_user)
         except exception_class as ce:
             einfo = ExceptionInfo()
             einfo.exception = ce
@@ -1494,12 +1495,12 @@ def cancel_export_provider_task(result=None, export_provider_task_uid=None, canc
                 priority=TaskPriority.CANCEL.value,
                 routing_key="{0}.cancel".format(export_task.worker))
 
-    if TaskStates[export_provider_task.status] not in TaskStates.get_finished_states():
+    if TaskStates[data_provider_task_record.status] not in TaskStates.get_finished_states():
         if error:
-            export_provider_task.status = TaskStates.FAILED.value
+            data_provider_task_record.status = TaskStates.FAILED.value
         else:
-            export_provider_task.status = TaskStates.CANCELED.value
-    export_provider_task.save()
+            data_provider_task_record.status = TaskStates.CANCELED.value
+    data_provider_task_record.save()
 
     return result
 
@@ -1510,41 +1511,39 @@ def cancel_run(result=None, export_run_uid=None, canceling_username=None, delete
 
     result = result or {}
 
-    export_run = ExportRun.objects.filter(uid=export_run_uid).first()
-
-    if not export_run:
-        result['result'] = False
-        return result
+    export_run = ExportRun.objects.get(uid=export_run_uid)
 
     for export_provider_task in export_run.provider_tasks.all():
-        cancel_export_provider_task(export_provider_task_uid=export_provider_task.uid,
+        cancel_export_provider_task(data_provider_task_uid=export_provider_task.uid,
                                     canceling_username=canceling_username, delete=delete,
                                     locking_task_key="cancel_export_provider_task-{0}".format(export_provider_task.uid))
     result['result'] = True
     return result
 
 
-@app.task(name='Kill Task', base=LockingTask)
+@app.task(name='Kill Task', base=UserDetailsBase)
 def kill_task(result=None, task_pid=None, celery_uid=None, *args, **kwargs):
     """
     Asks a worker to kill a task.
     """
 
-    import os, signal
     import celery
     result = result or {}
 
-    if task_pid:
-        # Don't kill tasks with default pid.
-        if task_pid <= 0:
-            return
+    if celery_uid:
         try:
             # Ensure the task is still running otherwise the wrong process will be killed
             if AsyncResult(celery_uid, app=app).state == celery.states.STARTED:
                 # If the task finished prior to receiving this kill message it could throw an OSError.
-                os.kill(task_pid, signal.SIGTERM)
+                logger.info("Attempting to kill {0}".format(task_pid))
+                # Don't kill tasks with default pid.
+                if task_pid > 0:
+                    progressive_kill(task_pid)
+            else:
+                logger.info("The celery_uid {0} has the status of {1}.".format(celery_uid,
+                                                                               AsyncResult(celery_uid, app=app).state))
         except OSError:
-            logger.info("{0} PID does not exist.")
+            logger.info("{0} PID does not exist.".format(task_pid))
     return result
 
 

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -16,6 +16,7 @@ from django.contrib.gis.geos import Polygon
 
 from django.core.cache import caches
 from django.core.mail import EmailMultiAlternatives
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import DatabaseError, transaction
 from django.template.loader import get_template, render_to_string
 from django.utils import timezone
@@ -1459,7 +1460,12 @@ def cancel_export_provider_task(result=None, data_provider_task_uid=None, cancel
 
     result = result or {}
     data_provider_task_record = DataProviderTaskRecord.objects.get(uid=data_provider_task_uid)
-    canceling_user = User.objects.get(username=canceling_username)
+
+    # There might not be a canceling user...
+    try:
+        canceling_user = User.objects.get(username=canceling_username)
+    except ObjectDoesNotExist:
+        canceling_user = None
 
     export_tasks = data_provider_task_record.tasks.all()
 

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -1,7 +1,13 @@
-import os, re
+import os
+import re
 from django.conf import settings
 from enum import Enum
+import logging
+import errno
+from time import sleep
+import signal
 
+logger = logging.getLogger()
 
 class Directory(Enum):
     ARCGIS = 'arcgis'
@@ -94,3 +100,22 @@ def normalize_name(name):
     # Replace all whitespace with a single underscore
     s = re.sub(r"\s+", '_', s)
     return s.lower()
+
+
+def progressive_kill(pid):
+    """
+    Tries to kill first with TERM and then with KILL.
+    :param pid: The process ID to kill
+    :return: None.
+    """
+    try:
+        logger.info("Trying to kill pid {0} with SIGTERM.".format(pid))
+        os.kill(pid, signal.SIGTERM)
+        sleep(5)
+
+        logger.info("Trying to kill pid {0} with SIGKILL.".format(pid))
+        os.kill(pid, signal.SIGKILL)
+        sleep(1)
+
+    except OSError:
+        logger.info("{0} PID no longer exists.".format(pid))

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -593,7 +593,7 @@ class TestExportTasks(ExportTaskBase):
         )
 
         self.assertEquals('Cancel Export Provider Task', cancel_export_provider_task.name)
-        cancel_export_provider_task.run(export_provider_task_uid=export_provider_task.uid,
+        cancel_export_provider_task.run(data_provider_task_uid=export_provider_task.uid,
                                         canceling_username=user.username)
         mock_kill_task.apply_async.assert_called_once_with(kwargs={"task_pid": task_pid, "celery_uid": celery_uid},
                                                            queue="{0}.cancel".format(worker_name),

--- a/eventkit_cloud/tasks/tests/test_helpers.py
+++ b/eventkit_cloud/tasks/tests/test_helpers.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import logging
+
+from django.test import TestCase
+from mock import patch, call
+import errno
+import signal
+
+from eventkit_cloud.tasks.helpers import progressive_kill
+
+logger = logging.getLogger(__name__)
+
+
+class TestHelpers(TestCase):
+    """
+    Test Task Helpers
+    """
+    @patch('eventkit_cloud.tasks.helpers.sleep')
+    @patch('eventkit_cloud.tasks.helpers.os')
+    def test_progessive_kill(self, mock_os, mock_sleep):
+        pid = 1
+        # Test no PID.
+        mock_os.kill.side_effect = [OSError()]
+        progressive_kill(pid)
+        mock_os.reset_mock
+
+        # Test kill with SIGTERM
+        mock_os.kill.side_effect = [None, OSError()]
+        progressive_kill(pid)
+        mock_os.kill.has_calls([call(pid, signal.SIGTERM)])
+        mock_os.reset_mock
+
+        # Test kill with SIGKILL
+        mock_os.kill.side_effect = [None, None]
+        progressive_kill(pid)
+        mock_os.kill.has_calls([call(pid, signal.SIGTERM), call(pid, signal.SIGTERM)])
+        mock_os.reset_mock
+
+


### PR DESCRIPTION
This fixes cancelling tasks by storing the parent ID instead of the current ID when the process is called.  Additionally some checks for canceled are fixed and some variable names are clarified.  

To test, create a task and attempt to cancel it in the UI.  If the task is sufficiently long running (i.e. for than 5 seconds) it should kill the process and display canceled in the UI.  Additionally the data source should not appear in the datapack. 