### PR TITLE
Drawer improvements

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/Application.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Application.js
@@ -29,6 +29,7 @@ import '../styles/bootstrap/css/bootstrap.css';
 import '../styles/openlayers/ol.css';
 import '../styles/flexboxgrid.css';
 import '../styles/react-joyride-compliled.css';
+import { isViewportL, isViewportXL, L_MAX_WIDTH } from '../utils/viewport';
 
 require('../fonts/index.css');
 
@@ -98,6 +99,7 @@ export class Application extends Component {
         this.notificationsPageSize = 10;
         this.notificationsUnreadCountIntervalId = null;
         this.notificationsRefreshIntervalId = null;
+        this.prevWindowWidth = 0;
     }
 
     getChildContext() {
@@ -364,6 +366,18 @@ export class Application extends Component {
 
     handleResize() {
         this.forceUpdate();
+
+        // Close the drawer if we resize down to mobile width.
+        if (isViewportL() && this.prevWindowWidth >= L_MAX_WIDTH) {
+            this.props.closeDrawer();
+        }
+
+        // Open the drawer if we resize up to desktop width.
+        if (isViewportXL() && this.prevWindowWidth < L_MAX_WIDTH) {
+            this.props.openDrawer();
+        }
+
+        this.prevWindowWidth = window.innerWidth;
     }
 
     handleClick(e) {

--- a/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
@@ -1,4 +1,5 @@
 import { userState, usersState } from './userReducer';
+import { isViewportXL } from '../utils/viewport';
 
 export default {
     auth: userState,
@@ -25,7 +26,7 @@ export default {
         error: null,
         filename: '',
     },
-    drawer: 'closed',
+    drawer: isViewportXL() ? 'open' : 'closed',
     runsList: {
         fetching: false,
         fetched: false,


### PR DESCRIPTION
The main menu drawer had stopped being open by default on desktop, so I fixed that while ensuring that it also starts closed on mobile.

I also made the main menu drawer open and close automatically as the window is resized between mobile breakpoints. This way when you size down to mobile you don't have a menu concealing the page by default, and when sizing up to desktop you aren't missing the drawer.