### PR TITLE
Proper fix for main menu drawer not opening at startup on large screens.

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/Application.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Application.js
@@ -100,6 +100,7 @@ export class Application extends Component {
         this.notificationsUnreadCountIntervalId = null;
         this.notificationsRefreshIntervalId = null;
         this.prevWindowWidth = 0;
+        this.loggedIn = false;
     }
 
     getChildContext() {
@@ -116,20 +117,21 @@ export class Application extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if (nextProps.userData !== this.props.userData) {
-            if (nextProps.userData != null) {
-                // if the user is logged in and the screen is large the drawer should be open
-                if (window.innerWidth >= 1200) {
-                    this.props.openDrawer();
-                }
-                this.startCheckingForAutoLogout();
-                this.startSendingUserActivePings();
-                this.startListeningForNotifications();
-            } else {
-                this.stopCheckingForAutoLogout();
-                this.stopSendingUserActivePings();
-                this.stopListeningForNotifications();
+        if (!this.loggedIn && nextProps.userData) {
+            this.loggedIn = true;
+            // If the user is logged in and the screen is large the drawer should be open
+            if (isViewportXL()) {
+                this.props.openDrawer();
             }
+            console.log('innerWidth', window.innerWidth);
+            this.startCheckingForAutoLogout();
+            this.startSendingUserActivePings();
+            this.startListeningForNotifications();
+        } else if (this.loggedIn && !nextProps.userData) {
+            this.loggedIn = false;
+            this.stopCheckingForAutoLogout();
+            this.stopSendingUserActivePings();
+            this.stopListeningForNotifications();
         }
     }
 
@@ -368,14 +370,16 @@ export class Application extends Component {
     handleResize() {
         this.forceUpdate();
 
-        // Close the drawer if we resize down to mobile width.
-        if (isViewportL() && this.prevWindowWidth >= L_MAX_WIDTH) {
-            this.props.closeDrawer();
-        }
+        if (this.loggedIn) {
+            // Close the drawer if we resize down to mobile width.
+            if (isViewportL() && this.prevWindowWidth >= L_MAX_WIDTH) {
+                this.props.closeDrawer();
+            }
 
-        // Open the drawer if we resize up to desktop width.
-        if (isViewportXL() && this.prevWindowWidth < L_MAX_WIDTH) {
-            this.props.openDrawer();
+            // Open the drawer if we resize up to desktop width.
+            if (isViewportXL() && this.prevWindowWidth < L_MAX_WIDTH) {
+                this.props.openDrawer();
+            }
         }
 
         this.prevWindowWidth = window.innerWidth;

--- a/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/initialState.js
@@ -1,5 +1,4 @@
 import { userState, usersState } from './userReducer';
-import { isViewportXL } from '../utils/viewport';
 
 export default {
     auth: userState,
@@ -26,7 +25,7 @@ export default {
         error: null,
         filename: '',
     },
-    drawer: isViewportXL() ? 'open' : 'closed',
+    drawer: 'closed',
     runsList: {
         fetching: false,
         fetched: false,

--- a/eventkit_cloud/ui/static/ui/app/tests/Application.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/Application.spec.js
@@ -197,10 +197,10 @@ describe('Application component', () => {
         props.drawer = 'open';
         const wrapper = getShallowWrapper(props);
         wrapper.instance().handleToggle();
-        expect(props.closeDrawer.calledOnce).toBe(true);
+        expect(props.closeDrawer.callCount).toBe(1);
         wrapper.setProps({ ...props, drawer: 'closed' });
         wrapper.instance().handleToggle();
-        expect(props.openDrawer.calledOnce).toBe(true);
+        expect(props.openDrawer.callCount).toBe(2);
     });
 
     it('onMenuItemClick should call handleToggle if screen size is smaller than 1200', () => {
@@ -352,6 +352,7 @@ describe('Application component', () => {
         const stopListeningForNotificationsSpy = sinon.spy(Application.prototype, 'stopListeningForNotifications');
         const wrapper = getMountedWrapper(getProps());
         const instance = wrapper.instance();
+        instance.loggedIn = true;
         wrapper.setProps({
             userData: null,
         });


### PR DESCRIPTION
I realized there was code in place for automatically opening the main menu drawer on startup based on the screen size. For some reason it had just become inconsistent, only occasionally working. There were also issues with my previous fix, so I reverted it and fixed the existing code.

I also fixed an issue where the drawer could be opened on the login screen by shrinking then expanding the window.