### PR TITLE
fix file path for arcgis metadata file

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -1061,7 +1061,8 @@ def prepare_for_export_zip_task(result=None, extra_files=None, run_uid=None, *ar
                 if ext in ['.gpkg', '.tif']:
                     download_filename = get_download_filename(os.path.splitext(os.path.basename(filename))[0],
                                                               timezone.now(),
-                                                              ext)
+                                                              ext,
+                                                              additional_descriptors=provider_task.slug)
                     filepath = get_archive_data_path(
                         provider_task.slug,
                         download_filename


### PR DESCRIPTION
This fixes an issue where in the project zip file ( for the entire datapack) in the metadata.json file (used to create the arcmap document) there was a missing descriptor from the filepath. 

