### PR TITLE
Replace slider mui

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/BufferDialog.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/BufferDialog.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import numeral from 'numeral';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
-import Slider from 'material-ui/Slider';
+import Slider from '@material-ui/lab/Slider';
 import AlertWarning from '@material-ui/icons/Warning';
 import Clear from '@material-ui/icons/Clear';
 import AlertCallout from './AlertCallout';
@@ -102,6 +102,12 @@ export class BufferDialog extends Component {
                 color: '#ce4427',
                 textAlign: 'left',
             },
+            slider: {
+                position: 'absolute',
+                width: '100%',
+                bottom: 0,
+                padding: '21px 0px',
+            },
         };
 
         const bufferActions = [
@@ -135,9 +141,6 @@ export class BufferDialog extends Component {
         if (!this.props.show) {
             return null;
         }
-
-        const sliderColor = this.props.valid ? '#4598bf' : '#d32f2f';
-        this.context.muiTheme.slider.selectionColor = sliderColor;
 
         let over = false;
         const maxAoi = this.props.maxVectorAoiSqKm;
@@ -227,13 +230,12 @@ export class BufferDialog extends Component {
                                     <tr>
                                         <td style={{ ...styles.tableData, borderLeft: '1px solid #ccc' }} >
                                             <Slider
-                                                style={{ position: 'absolute', width: '100%', bottom: 0 }}
-                                                sliderStyle={{ marginTop: '12px', marginBottom: '14px' }}
+                                                style={styles.slider}
                                                 step={10}
                                                 max={10000}
                                                 min={0}
                                                 value={this.props.value}
-                                                onChange={(e, v) => this.props.handleBufferChange(v)}
+                                                onChange={(e, value) => this.props.handleBufferChange(value)}
                                             />
                                         </td>
                                         <td style={{ ...styles.tableData, borderRight: '1px solid #ccc' }} />
@@ -260,10 +262,6 @@ export class BufferDialog extends Component {
 
 BufferDialog.defaultProps = {
     maxVectorAoiSqKm: null,
-};
-
-BufferDialog.contextTypes = {
-    muiTheme: PropTypes.object.isRequired,
 };
 
 BufferDialog.propTypes = {

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -116,7 +116,7 @@ export class ExportAOI extends Component {
             if (valid !== this.state.valid) {
                 this.setState({ validBuffer: valid });
             }
-        }, 50);
+        }, 10);
 
         this.initializeOpenLayers();
         if (Object.keys(this.props.aoiInfo.geojson).length !== 0) {
@@ -684,7 +684,6 @@ export class ExportAOI extends Component {
     handleBufferChange(value) {
         const buffer = Number(value);
         if (buffer <= 10000 && buffer >= 0) {
-            // this.setState({ buffer });
             this.props.updateAoiInfo({ ...this.props.aoiInfo, buffer });
             const { geojson } = this.props.aoiInfo;
             if (Object.keys(geojson).length === 0) {

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/BufferDialog.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/BufferDialog.spec.js
@@ -1,16 +1,13 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
 import TextField from '@material-ui/core/TextField';
-import Slider from 'material-ui/Slider';
+import Slider from '@material-ui/lab/Slider';
 import Clear from '@material-ui/icons/Clear';
 import AlertCallout from '../../components/CreateDataPack/AlertCallout';
 import BufferDialog from '../../components/CreateDataPack/BufferDialog';
 
 describe('AlertCallout component', () => {
-    const muiTheme = getMuiTheme();
     const getProps = () => (
         {
             show: true,
@@ -24,10 +21,7 @@ describe('AlertCallout component', () => {
     );
 
     const getWrapper = props => (
-        mount(<BufferDialog {...props} />, {
-            context: { muiTheme },
-            childContextTypes: { muiTheme: PropTypes.object },
-        })
+        mount(<BufferDialog {...props} />)
     );
 
     it('should render the basic elements', () => {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@material-ui/core": "~3.0.0",
     "@material-ui/icons": "~3.0.0",
+    "@material-ui/lab": "~1.0.0-alpha.12",
     "axios": "~0.15.3",
     "babel-polyfill": "~6.23.0",
     "jsts": "~1.4.0",


### PR DESCRIPTION
This PR replaces the mui v0.x slider with a slider from MUI Labs. MUI labs holds the v1+ components that are in the works but not ready for official release. The labs slider has the same functionality as the v0.x one so it is easy to switch over. When the slider is moved from labs to core we will need to update it again.
** this was branched from update-last-components-mui so make sure that one gets merged in first **