### PR TITLE
EVK-90 dont duplicate users in list

### DIFF
--- a/eventkit_cloud/api/views.py
+++ b/eventkit_cloud/api/views.py
@@ -1630,7 +1630,7 @@ class NotificationViewSet(viewsets.GenericViewSet):
     @list_route(methods=['get'])
     def counts(self, request, *args, **kwargs):
         payload = {
-            "read" : len(request.user.notifications.read()),
+            "read": len(request.user.notifications.read()),
             "unread": len(request.user.notifications.unread())
         }
 

--- a/eventkit_cloud/tasks/models.py
+++ b/eventkit_cloud/tasks/models.py
@@ -19,8 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 def get_all_users_by_permissions(permissions):
-    return User.objects.filter(models.Q(groups__name=permissions['groups']) | models.Q(username__in=permissions['users']))
-
+    return User.objects.filter(
+        models.Q(groups__name=permissions['groups']) |
+        models.Q(username__in=permissions['users'])
+    ).distinct()
 
 def notification_delete(instance):
     for notification in Notification.objects.filter(actor_object_id=instance.id):


### PR DESCRIPTION
EVK-90 should fix the issue with multiple delete notifications being generated. The users_by_permissions query was returning duplicates of a user. Fixed to only return one instance of any given user object. No UI changes.