### PR TITLE
EVK-91 fix the color of the canceled icon

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
@@ -142,7 +142,7 @@ export class ProviderRow extends Component {
                             className="qa-ProviderRow-Warning-providerStatus"
                             style={{
                                 marginLeft: '10px',
-                                fill: colors.warning,
+                                fill: colors.running,
                                 verticalAlign: 'bottom',
                             }}
                         />

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
@@ -282,7 +282,7 @@ describe('ProviderRow component', () => {
                     className="qa-ProviderRow-Warning-providerStatus"
                     style={{
                         marginLeft: '10px',
-                        fill: '#ce4427',
+                        fill: '#f4d225',
                         verticalAlign: 'bottom',
                     }}
                 />


### PR DESCRIPTION
EVK-91 fixes the inconsistent status icon color for a canceled DataPack

![image](https://user-images.githubusercontent.com/16799449/45952962-a1027700-bfd6-11e8-9520-16d24c7aaa9b.png)

