### PR TITLE
EVK-15 fixed issue with getting timestamp

### DIFF
--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -329,9 +329,8 @@ def get_osm_last_update(url, slug=None):
     :param slug: Optionally a slug if credentials are needed
     :return: The default timestamp as a string (2018-06-18T13:09:59Z)
     """
-
-    timestamp_url = "{0}timestamp".format(url.rstrip('/').rstrip('interpreter'))
     try:
+        timestamp_url = "{0}timestamp".format(url.rstrip('/').rstrip('interpreter'))
         response = auth_requests.get(timestamp_url, slug=slug)
         if response:
             return response.content


### PR DESCRIPTION
This fixes an issue where if there is no url provided for OSM, it won't fail. 