### PR TITLE
EK-135 fix filtering for status and providers

### DIFF
--- a/eventkit_cloud/api/filters.py
+++ b/eventkit_cloud/api/filters.py
@@ -17,7 +17,8 @@ class ListFilter(django_filters.Filter):
     def filter(self, qs, value):
         if value:
             value_list = value.split(',')
-            return super(ListFilter, self).filter(qs, django_filters.fields.Lookup(value_list, 'in')).distinct()
+            lookup = '{}__in'.format(self.field_name)
+            return self.get_method(qs)(**{lookup: value_list})
         else:
             return qs
           


### PR DESCRIPTION
This fixes a regression with filtering.  

To test create several datapacks, then try to filter on status, and/or provider to ensure the selected options appear in the list. 