### PR TITLE
EVK-136 fixed admin, add TaskResults view, fix Downloads

### DIFF
--- a/eventkit_cloud/tasks/admin.py
+++ b/eventkit_cloud/tasks/admin.py
@@ -1,11 +1,51 @@
+from django import forms
 from django.contrib import admin
 
-from eventkit_cloud.tasks.models import ExportRun, UserDownload
+from eventkit_cloud.tasks.models import ExportRun, UserDownload, ExportTaskRecord, FileProducingTaskResult, \
+    ExportTaskException
+
+from eventkit_cloud.tasks.export_tasks import TaskStates
+
+import logging
+import pickle
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
+class ExportTaskRecordAdmin(admin.ModelAdmin):
+    model = ExportTaskRecord
+
+    readonly_fields = ('export_provider_task', 'celery_uid', 'name', 'status', 'progress', 'estimated_finish',
+                       'pid', 'worker', 'cancel_user', 'result', 'exceptions')
+    search_fields = ['uid', 'name', 'status', 'export_provider_task__uid', 'export_provider_task__slug']
+
+    @staticmethod
+    def exceptions(obj):
+
+        exceptions = []
+        for exc in obj.exceptions.all():
+            # set a default (incase not found)
+            exc_info = ["", "Exception info not found or unreadable."]
+            try:
+                exc_info = pickle.loads(exc.exception.encode()).exc_info
+            except Exception as te:
+                logger.warning(te)
+            exceptions += [' '.join(traceback.format_exception(*exc_info))]
+        return '\n'.join(exceptions)
+
+    list_display = ['uid', 'name', 'progress', 'status', 'display']
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 class ExportRunAdmin(admin.ModelAdmin):
-    readonly_fields=('delete_user', 'user', 'status', 'started_at', 'finished_at')
+    readonly_fields = ('delete_user', 'user', 'status', 'started_at', 'finished_at')
     list_display = ['uid', 'status', 'user', 'notified', 'expiration', 'deleted']
+
+    def has_add_permission(self, request, obj=None):
+        return False
 
 
 class UserDownloadAdmin(admin.ModelAdmin):
@@ -18,6 +58,7 @@ class UserDownloadAdmin(admin.ModelAdmin):
             return 'DataPack Zip'
         else:
             return self.provider.slug
+
     list_display_provider.short_description = 'Provider'
     model = UserDownload
 
@@ -31,3 +72,4 @@ class UserDownloadAdmin(admin.ModelAdmin):
 
 admin.site.register(ExportRun, ExportRunAdmin)
 admin.site.register(UserDownload, UserDownloadAdmin)
+admin.site.register(ExportTaskRecord, ExportTaskRecordAdmin)

--- a/eventkit_cloud/tasks/admin.py
+++ b/eventkit_cloud/tasks/admin.py
@@ -18,7 +18,8 @@ class ExportTaskRecordAdmin(admin.ModelAdmin):
 
     readonly_fields = ('export_provider_task', 'celery_uid', 'name', 'status', 'progress', 'estimated_finish',
                        'pid', 'worker', 'cancel_user', 'result', 'exceptions')
-    search_fields = ['uid', 'name', 'status', 'export_provider_task__uid', 'export_provider_task__slug']
+    search_fields = ['uid', 'name', 'status', 'export_provider_task__uid', 'export_provider_task__slug',
+                     'export_provider_task__run__uid', 'export_provider_task__run__job__uid']
 
     @staticmethod
     def exceptions(obj):

--- a/eventkit_cloud/tasks/models.py
+++ b/eventkit_cloud/tasks/models.py
@@ -24,6 +24,7 @@ def get_all_users_by_permissions(permissions):
         models.Q(username__in=permissions['users'])
     ).distinct()
 
+
 def notification_delete(instance):
     for notification in Notification.objects.filter(actor_object_id=instance.id):
         ct = ContentType.objects.filter(pk=notification.actor_content_type_id).get()
@@ -164,16 +165,16 @@ class UserDownload(UIDMixin):
 
     @property
     def job(self):
-        if self.downloadable.task:
-            return self.downloadable.task.export_provider_task.run.job
+        if self.downloadable.export_task:
+            return self.downloadable.export_task.export_provider_task.run.job
         if self.downloadable.run:
             return self.downloadable.run.job
 
     @property
     def provider(self):
         # TODO: This is one of many reasons why DataProviderTaskRecord should maybe point to DataProvider
-        if self.downloadable.task:
-            return DataProvider.objects.filter(slug=self.downloadable.task.export_provider_task.slug).first()
+        if self.downloadable.export_task:
+            return DataProvider.objects.filter(slug=self.downloadable.export_task.export_provider_task.slug).first()
 
 
 class ExportTaskRecord(UIDMixin, TimeStampedModelMixin, TimeTrackingModelMixin):


### PR DESCRIPTION
This adds an admin view for the Task Results, which allows administrators to view exceptions. 
![image](https://user-images.githubusercontent.com/6437951/46874963-743cc500-ce08-11e8-99cf-c5560098b817.png)

![image](https://user-images.githubusercontent.com/6437951/46874969-7737b580-ce08-11e8-9a6a-addb40244829.png)

Additionally it fixes some links in the models which broke viewing download records, to verify the fix, simply view UserDownloads in the admin page.