### PR TITLE
EVK-151 provider loading bug

### DIFF
--- a/config/ui/.eslintrc.json
+++ b/config/ui/.eslintrc.json
@@ -28,7 +28,8 @@
         "react/jsx-indent": [2, 4],
         "react/jsx-indent-props": [2, 4],
         "react/prefer-stateless-function": "off",
-		"react/forbid-prop-types": ["error", { "forbid": ["any", "array"] }]
+        "react/forbid-prop-types": ["error", { "forbid": ["any", "array"] }],
+        "react/no-did-update-set-state": "warn"
     },
     "settings": {
         "import/resolver": {

--- a/eventkit_cloud/ui/static/ui/app/components/AccountPage/Account.js
+++ b/eventkit_cloud/ui/static/ui/app/components/AccountPage/Account.js
@@ -42,8 +42,8 @@ export class Account extends Component {
         this.joyrideAddSteps(steps);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.user.status.patched && !this.props.user.status.patched) {
+    componentDidUpdate(prevProps) {
+        if (this.props.user.status.patched && !prevProps.user.status.patched) {
             this.setState({ showSavedMessage: true });
             window.setTimeout(() => {
                 this.setState({ showSavedMessage: false });

--- a/eventkit_cloud/ui/static/ui/app/components/Application.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/Application.tsx
@@ -263,23 +263,23 @@ export class Application extends React.Component<Props, State> {
         window.addEventListener('click', this.handleClick);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (this.loggedIn && nextProps.width !== this.props.width) {
-            if (nextProps.width === 'xl') {
+    componentDidUpdate(prevProps) {
+        if (this.loggedIn && this.props.width !== prevProps.width) {
+            if (this.props.width === 'xl') {
                 this.props.openDrawer();
-            } else if (this.props.width === 'xl') {
+            } else if (prevProps.width === 'xl') {
                 this.props.closeDrawer();
             }
         }
-        if (!this.loggedIn && nextProps.userData) {
+        if (!this.loggedIn && this.props.userData) {
             this.loggedIn = true;
-            if (nextProps.width === 'xl') {
+            if (this.props.width === 'xl') {
                 this.props.openDrawer();
             }
             this.startCheckingForAutoLogout();
             this.startSendingUserActivePings();
             this.startListeningForNotifications();
-        } else if (this.loggedIn && !nextProps.userData) {
+        } else if (this.loggedIn && !this.props.userData) {
             this.loggedIn = false;
             this.stopCheckingForAutoLogout();
             this.stopSendingUserActivePings();

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/BreadcrumbStepper.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/BreadcrumbStepper.js
@@ -64,21 +64,20 @@ export class BreadcrumbStepper extends React.Component {
         this.props.router.setRouteLeaveHook(route, this.routeLeaveHook);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.jobFetched && !this.props.jobFetched) {
-            this.hideLoading();
-            browserHistory.push(`/status/${nextProps.jobuid}`);
+    componentDidUpdate(prevProps) {
+        if (this.props.jobFetched && !prevProps.jobFetched) {
             this.props.clearJobInfo();
             this.props.getNotifications();
             this.props.getNotificationsUnreadCount();
+            browserHistory.push(`/status/${this.props.jobuid}`);
         }
-        if (nextProps.jobError && !this.props.jobError) {
+        if (this.props.jobError && !prevProps.jobError) {
             this.hideLoading();
-            this.showError(nextProps.jobError);
+            this.showError(this.props.jobError);
         }
 
-        if (!isEqual(nextProps.aoiInfo, this.props.aoiInfo) ||
-            !isEqual(nextProps.exportInfo, this.props.exportInfo)) {
+        if (!isEqual(this.props.aoiInfo, prevProps.aoiInfo) ||
+            !isEqual(this.props.exportInfo, prevProps.exportInfo)) {
             this.setState({ modified: true });
         }
     }

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -140,18 +140,16 @@ export class ExportAOI extends Component {
         this.joyrideAddSteps(steps);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.importGeom.processed && !this.props.importGeom.processed) {
-            this.handleGeoJSONUpload(nextProps.importGeom);
+    componentDidUpdate(prevProps) {
+        if (this.props.importGeom.processed && !prevProps.importGeom.processed) {
+            this.handleGeoJSONUpload(this.props.importGeom);
         }
 
-        if (nextProps.walkthroughClicked && !this.props.walkthroughClicked && this.state.isRunning === false) {
+        if (this.props.walkthroughClicked && !prevProps.walkthroughClicked && this.state.isRunning === false) {
             this.joyride.reset(true);
             this.setState({ isRunning: true });
         }
-    }
 
-    componentDidUpdate() {
         this.map.updateSize();
     }
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -66,7 +66,7 @@ export class ExportInfo extends React.Component {
 
         // make requests to check provider availability
         if (this.state.providers) {
-            this.fetch = setInterval(this.state.providers.forEach((provider) => {
+            this.fetch = window.setInterval(this.state.providers.forEach((provider) => {
                 if (provider.display === false) return;
                 this.checkAvailability(provider);
             }), 30000);
@@ -75,21 +75,21 @@ export class ExportInfo extends React.Component {
         this.joyrideAddSteps(steps);
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentDidUpdate(prevProps) {
         // if currently in walkthrough, we want to be able to show the green forward button, so ignore these statements
-        if (!nextProps.walkthroughClicked) {
+        if (!this.props.walkthroughClicked) {
         // if required fields are fulfilled enable next
-            if (this.hasRequiredFields(nextProps.exportInfo) &&
-                !this.hasDisallowedSelection(nextProps.exportInfo)) {
-                if (!nextProps.nextEnabled) {
+            if (this.hasRequiredFields(this.props.exportInfo) &&
+                !this.hasDisallowedSelection(this.props.exportInfo)) {
+                if (!this.props.nextEnabled) {
                     this.props.setNextEnabled();
                 }
-            } else if (nextProps.nextEnabled) {
+            } else if (this.props.nextEnabled) {
                 // if not and next is enabled it should be disabled
                 this.props.setNextDisabled();
             }
         }
-        if (nextProps.walkthroughClicked && !this.props.walkthroughClicked && !this.state.isRunning) {
+        if (this.props.walkthroughClicked && !prevProps.walkthroughClicked && !this.state.isRunning) {
             this.joyride.reset(true);
             this.setState({ isRunning: true });
         }

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -47,6 +47,11 @@ export class ExportInfo extends React.Component {
         this.handleRefreshTooltipClose = this.handleRefreshTooltipClose.bind(this);
         this.onChangeCheck = this.onChangeCheck.bind(this);
         this.onRefresh = this.onRefresh.bind(this);
+        this.getAvailability = this.getAvailability.bind(this);
+        this.checkAvailability = this.checkAvailability.bind(this);
+        this.checkProviders = this.checkProviders.bind(this);
+
+        this.joyride = React.createRef();
     }
 
     componentDidMount() {
@@ -66,11 +71,9 @@ export class ExportInfo extends React.Component {
 
         // make requests to check provider availability
         if (this.state.providers) {
-            this.fetch = window.setInterval(this.state.providers.forEach((provider) => {
-                if (provider.display === false) return;
-                this.checkAvailability(provider);
-            }), 30000);
+            this.checkProviders(this.state.providers);
         }
+
         const steps = joyride.ExportInfo;
         this.joyrideAddSteps(steps);
     }
@@ -92,6 +95,11 @@ export class ExportInfo extends React.Component {
         if (this.props.walkthroughClicked && !prevProps.walkthroughClicked && !this.state.isRunning) {
             this.joyride.reset(true);
             this.setState({ isRunning: true });
+        }
+
+        if (this.props.providers.length !== prevProps.providers.length) {
+            this.setState({ providers: this.props.providers });
+            this.checkProviders(this.props.providers);
         }
     }
 
@@ -170,13 +178,12 @@ export class ExportInfo extends React.Component {
         });
     }
 
-    checkAvailability(provider) {
+    getAvailability(provider, data) {
         // make a copy of the provider to edit
         const newProvider = { ...provider };
 
-        const data = { geojson: this.props.geojson };
         const csrfmiddlewaretoken = cookie.load('csrftoken');
-        axios({
+        return axios({
             url: `/api/providers/${provider.slug}/status`,
             method: 'POST',
             data,
@@ -184,26 +191,34 @@ export class ExportInfo extends React.Component {
         }).then((response) => {
             newProvider.availability = JSON.parse(response.data);
             newProvider.availability.slug = provider.slug;
-            this.setState((prevState) => {
-                // make a copy of state providers and replace the one we updated
-                const providers = [...prevState.providers];
-                providers.splice(providers.indexOf(provider), 1, newProvider);
-                return { providers };
-            });
+            return newProvider;
         }).catch((error) => {
-            console.log(error);
+            console.error(error);
             newProvider.availability = {
                 status: 'WARN',
                 type: 'CHECK_FAILURE',
                 message: "An error occurred while checking this provider's availability.",
             };
             newProvider.availability.slug = provider.slug;
-            this.setState((prevState) => {
-                // make a copy of state providers and replace the one we updated
-                const providers = [...prevState.providers];
-                providers.splice(providers.indexOf(provider), 1, newProvider);
-                return { providers };
-            });
+            return newProvider;
+        });
+    }
+
+    async checkAvailability(provider) {
+        const data = { geojson: this.props.geojson };
+        const newProvider = await this.getAvailability(provider, data);
+        this.setState((prevState) => {
+            // make a copy of state providers and replace the one we updated
+            const providers = [...prevState.providers];
+            providers.splice(providers.indexOf(provider), 1, newProvider);
+            return { providers };
+        });
+    }
+
+    checkProviders(providers) {
+        providers.forEach((provider) => {
+            if (provider.display === false) return;
+            this.checkAvailability(provider);
         });
     }
 
@@ -249,12 +264,7 @@ export class ExportInfo extends React.Component {
     }
 
     joyrideAddSteps(steps) {
-        let newSteps = steps;
-
-        if (!Array.isArray(newSteps)) {
-            newSteps = [newSteps];
-        }
-
+        const newSteps = steps;
         if (!newSteps.length) return;
 
         this.setState((currentState) => {
@@ -375,7 +385,7 @@ export class ExportInfo extends React.Component {
             <div id="root" className="qa-ExportInfo-root" style={style.root}>
                 <Joyride
                     callback={this.callback}
-                    ref={(instance) => { this.joyride = instance; }}
+                    ref={this.joyride}
                     steps={steps}
                     autoStart
                     type="continuous"

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportSummary.js
@@ -24,8 +24,8 @@ export class ExportSummary extends Component {
         this.joyrideAddSteps(steps);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.walkthroughClicked && !this.props.walkthroughClicked && !this.state.isRunning) {
+    componentDidUpdate(prevProps) {
+        if (this.props.walkthroughClicked && !prevProps.walkthroughClicked && !this.state.isRunning) {
             this.joyride.reset(true);
             this.setState({ isRunning: true });
         }

--- a/eventkit_cloud/ui/static/ui/app/components/CustomTextField.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CustomTextField.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withTheme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
-import * as ReactDOM from 'react-dom';
 
 export class CustomTextField extends Component {
     constructor(props) {
@@ -84,6 +83,11 @@ export class CustomTextField extends Component {
             ...rest
         } = this.props;
 
+        const inputStyle = {
+            paddingRight: maxLength && showRemaining ? '55px' : 'unset',
+            ...InputProps.style,
+        };
+
         const charsRemainingColor = (this.state.charsRemaining > 10) ? theme.eventkit.colors.text_primary : theme.eventkit.colors.warning;
 
         return (
@@ -91,22 +95,12 @@ export class CustomTextField extends Component {
                 <TextField
                     className="qa-CustomTextField-TextField"
                     id="custom-text-field"
-                    ref={(textField) => {
-                        if (!textField) {
-                            return;
-                        }
-
-                        if (maxLength && showRemaining) {
-                            // eslint-disable-next-line react/no-find-dom-node
-                            ReactDOM.findDOMNode(textField).style.paddingRight = '55px';
-                        }
-                    }}
                     onChange={this.onChange}
                     onFocus={this.onFocus}
                     onBlur={this.onBlur}
                     inputProps={{ maxLength, ...inputProps }}
                     // eslint-disable-next-line react/jsx-no-duplicate-props
-                    InputProps={{ ...InputProps }}
+                    InputProps={{ ...InputProps, style: inputStyle }}
                     type="text"
                     {...rest}
                 />

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/DataPackPage.js
@@ -118,12 +118,7 @@ export class DataPackPage extends React.Component {
         return true;
     }
 
-    componentDidUpdate(prevProps) { /* eslint-disable react/no-did-update-set-state */
-        // setState is permitted in componentDidUpdate, but you
-        // must wrap it in a conditional and be cautious
-        // https://reactjs.org/docs/react-component.html#componentdidupdate
-        // eslint-disable-next-line react/no-did-update-set-state
-        // if fetched WAS null but now TRUE we can show the page
+    componentDidUpdate(prevProps) {
         if (prevProps.runsFetched === null && this.props.runsFetched) {
             if (this.state.pageLoading) {
                 this.setState({ pageLoading: false });

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -174,11 +174,11 @@ export class MapView extends Component {
         this.map.getView().on('propertychange', this.updateZoomLevel);
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentDidUpdate(prevProps) {
         // if the runs have changed, clear out old features and re-add with new features
-        if (this.hasNewRuns(this.props.runs, nextProps.runs)) {
+        if (this.hasNewRuns(prevProps.runs, this.props.runs)) {
             this.source.clear();
-            const added = this.addRunFeatures(nextProps.runs, this.source);
+            const added = this.addRunFeatures(this.props.runs, this.source);
             const drawExtent = this.drawLayer.getSource().getExtent();
             const runsExtent = this.source.getExtent();
             // if any features were added to the source
@@ -201,13 +201,11 @@ export class MapView extends Component {
             }
         }
 
-        if (nextProps.importGeom.processed && !this.props.importGeom.processed) {
-            this.handleGeoJSONUpload(nextProps.importGeom.featureCollection);
+        if (this.props.importGeom.processed && !prevProps.importGeom.processed) {
+            this.handleGeoJSONUpload(this.props.importGeom.featureCollection);
         }
-    }
 
-    // update map size so it doesnt look like crap after page resize
-    componentDidUpdate() {
+        // update map size so it doesnt look like crap after page resize
         this.map.updateSize();
     }
 

--- a/eventkit_cloud/ui/static/ui/app/components/MapTools/DropZoneError.js
+++ b/eventkit_cloud/ui/static/ui/app/components/MapTools/DropZoneError.js
@@ -12,11 +12,11 @@ export class DropZoneError extends Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.importGeom.error !== this.props.importGeom.error) {
-            if (nextProps.importGeom.error) {
+    componentDidUpdate(prevProps) {
+        if (this.props.importGeom.error !== prevProps.importGeom.error) {
+            if (this.props.importGeom.error) {
                 this.props.setAllButtonsDefault();
-                this.setState({ showErrorMessage: true, errorMessage: nextProps.importGeom.error });
+                this.setState({ showErrorMessage: true, errorMessage: this.props.importGeom.error });
             }
         }
     }

--- a/eventkit_cloud/ui/static/ui/app/components/MapTools/SearchAOIToolbar.js
+++ b/eventkit_cloud/ui/static/ui/app/components/MapTools/SearchAOIToolbar.js
@@ -24,14 +24,14 @@ export class SearchAOIToolbar extends Component {
         this.debouncer = debounce(e => this.handleChange(e), 500);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.geocode.fetched === true) {
-            this.setState({ suggestions: nextProps.geocode.data });
-        } else if (this.state.suggestions.length > 0) {
+    componentDidUpdate(prevProps) {
+        if (this.props.geocode.fetched === true && !prevProps.geocode.fetched) {
+            this.setState({ suggestions: this.props.geocode.data });
+        } else if (!this.props.geocode.fetched && this.state.suggestions.length > 0) {
             this.setState({ suggestions: [] });
         }
-        if (nextProps.toolbarIcons.search !== this.props.toolbarIcons.search) {
-            if (nextProps.toolbarIcons.search === 'DEFAULT') {
+        if (this.props.toolbarIcons.search !== prevProps.toolbarIcons.search) {
+            if (this.props.toolbarIcons.search === 'DEFAULT') {
                 this.typeaheadref.getInstance().clear();
             }
         }
@@ -128,7 +128,7 @@ export class SearchAOIToolbar extends Component {
                         <TypeaheadMenuItem
                             result={result}
                             index={index}
-                            key={`${result.name}${result.province}${result.region}${result.country}`}
+                            key={JSON.stringify(result.properties)}
                         />
                     ));
                 } else {

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsDropdown.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsDropdown.js
@@ -18,8 +18,8 @@ export class NotificationsDropdown extends React.Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.status.fetched && !this.props.status.fetched) {
+    componentDidUpdate(prevProps) {
+        if (this.props.status.fetched && !prevProps.status.fetched) {
             this.setState({ showLoading: false });
         }
     }

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationsTable.js
@@ -25,14 +25,14 @@ export class NotificationsTable extends React.Component {
         };
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.notificationsData !== this.props.notificationsData) {
+    componentDidUpdate(prevProps) {
+        if (this.props.notificationsData !== prevProps.notificationsData) {
             // Make sure to deselect any notifications that have been removed. Handle it here instead of
             // the standard callback in case it was removed by the notifications dropdown.
             const selected = { ...this.state.selected };
 
             Object.keys(selected).forEach((uid) => {
-                if (!nextProps.notificationsData.notifications[uid]) {
+                if (!this.props.notificationsData.notifications[uid]) {
                     delete selected[uid];
                 }
             });

--- a/eventkit_cloud/ui/static/ui/app/components/NotificationsPage/NotificationsPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/NotificationsPage/NotificationsPage.js
@@ -32,8 +32,8 @@ export class NotificationsPage extends React.Component {
         this.refresh();
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.notificationsStatus.fetched && !this.props.notificationsStatus.fetched) {
+    componentDidUpdate(prevProps) {
+        if (this.props.notificationsStatus.fetched && !prevProps.notificationsStatus.fetched) {
             this.setState({
                 loadingPage: false,
                 loading: false,

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/ProviderRow.js
@@ -31,7 +31,7 @@ export class ProviderRow extends Component {
         this.state = {
             openTable: false,
             selectedRows: { },
-            fileSize: null,
+            fileSize: this.getFileSize(props.provider.tasks),
             providerDesc: '',
             providerDialogOpen: false,
         };
@@ -45,22 +45,30 @@ export class ProviderRow extends Component {
         this.setState({ selectedRows: rows });
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentDidUpdate(prevProps) {
+        if (this.props.provider.status !== prevProps.provider.status) {
+            this.setState({ fileSize: this.getFileSize(this.props.provider.tasks) });
+        }
+        if (this.props.selectedProviders !== this.state.selectedRows) {
+            this.setState({ selectedRows: this.props.selectedProviders });
+        }
+    }
+
+    getFileSize(tasks) {
         let fileSize = 0.000;
-        nextProps.provider.tasks.forEach((task) => {
+        tasks.forEach((task) => {
             if (task.result != null) {
                 if (task.display !== false && task.result.size) {
                     const textReplace = task.result.size.replace(' MB', '');
                     const number = textReplace;
                     fileSize = Number(fileSize) + Number(number);
-                    this.setState({ fileSize: fileSize.toFixed(3) });
                 }
             }
         });
 
-        if (nextProps.selectedProviders !== this.state.selectedRows) {
-            this.setState({ selectedRows: nextProps.selectedProviders });
-        }
+        if (fileSize === 0.000) return null;
+
+        return fileSize.toFixed(3);
     }
 
     getTextFontSize() {

--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/StatusDownload.js
@@ -63,36 +63,47 @@ export class StatusDownload extends React.Component {
         this.joyrideAddSteps(steps);
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (nextProps.runDeletion.deleted && !this.props.runDeletion.deleted) {
+    shouldComponentUpdate(p) {
+        if (p.detailsFetched !== this.props.detailsFetched) {
+            if (p.runs !== this.props.runs || this.state.isLoading) {
+                return true;
+            }
+            return false;
+        }
+
+        return true;
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.runDeletion.deleted && !prevProps.runDeletion.deleted) {
             browserHistory.push('/exports');
         }
-        if (nextProps.exportReRun.error && !this.props.exportReRun.error) {
-            this.setState({ error: nextProps.exportReRun.error });
+        if (this.props.exportReRun.error && !prevProps.exportReRun.error) {
+            this.setState({ error: this.props.exportReRun.error });
         }
-        if (nextProps.exportReRun.fetched && !this.props.exportReRun.fetched) {
+        if (this.props.exportReRun.fetched && !prevProps.exportReRun.fetched) {
             this.props.getDatacartDetails(this.props.router.params.jobuid);
             this.startTimer();
         }
-        if (nextProps.expirationState.updated && !this.props.expirationState.updated) {
+        if (this.props.expirationState.updated && !prevProps.expirationState.updated) {
             this.props.getDatacartDetails(this.props.router.params.jobuid);
         }
-        if (nextProps.permissionState.updated && !this.props.permissionState.updated) {
+        if (this.props.permissionState.updated && !prevProps.permissionState.updated) {
             this.props.getDatacartDetails(this.props.router.params.jobuid);
         }
-        if (nextProps.detailsFetched && !this.props.detailsFetched) {
+        if (this.props.detailsFetched && !prevProps.detailsFetched) {
             if (this.state.isLoading) {
                 this.setState({ isLoading: false });
             }
 
             // If no data returned from API we stop here
-            if (!nextProps.runIds.length) {
+            if (!this.props.runIds.length) {
                 return;
             }
 
-            const datacart = nextProps.runs;
+            const datacart = this.props.runs;
             let clearTimer = true;
-            if (nextProps.runs[0].zipfile_url == null) {
+            if (this.props.runs[0].zipfile_url == null) {
                 clearTimer = false;
             }
 
@@ -123,23 +134,12 @@ export class StatusDownload extends React.Component {
             }
         }
 
-        if (nextProps.location.pathname !== this.props.location.pathname) {
+        if (this.props.location.pathname !== prevProps.location.pathname) {
             // Refresh the entire component.
             this.componentWillUnmount();
             this.setState(this.getInitialState());
             this.componentDidMount();
         }
-    }
-
-    shouldComponentUpdate(p) {
-        if (p.detailsFetched !== this.props.detailsFetched) {
-            if (p.runs !== this.props.runs || this.state.isLoading) {
-                return true;
-            }
-            return false;
-        }
-
-        return true;
     }
 
     componentWillUnmount() {

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserGroupsPage.js
@@ -108,7 +108,7 @@ export class UserGroupsPage extends Component {
         // If there is no ordering specified default to username
         if (!this.props.location.query.ordering) {
             // Set the current ordering to username so a change wont be detected
-            // by componentWillReceiveProps
+            // by componentDidUpdate
             this.props.location.query.ordering = 'username';
             // Replace the url with the ordering query included
             browserHistory.replace({
@@ -126,29 +126,29 @@ export class UserGroupsPage extends Component {
         this.joyrideAddSteps(steps);
     }
 
-    componentWillReceiveProps(nextProps) {
+    componentDidUpdate(prevProps) {
         let changedQuery = false;
-        if (Object.keys(nextProps.location.query).length
-                !== Object.keys(this.props.location.query).length) {
+        if (Object.keys(this.props.location.query).length
+                !== Object.keys(prevProps.location.query).length) {
             changedQuery = true;
         } else {
-            const keys = Object.keys(nextProps.location.query);
-            if (!keys.every(key => nextProps.location.query[key] === this.props.location.query[key])) {
+            const keys = Object.keys(this.props.location.query);
+            if (!keys.every(key => this.props.location.query[key] === prevProps.location.query[key])) {
                 changedQuery = true;
             }
         }
         if (changedQuery) {
-            this.makeUserRequest({ ...nextProps.location.query });
+            this.makeUserRequest({ ...this.props.location.query });
         }
 
-        if (nextProps.users.fetched && !this.props.users.fetched) {
+        if (this.props.users.fetched && !prevProps.users.fetched) {
             // if we have new props.user array and there are selectedUsers
             // we need to create a new selectedUsers array, removing any users
             // not in the new props.users array
             if (this.state.selectedUsers.length) {
                 const fixedSelection = [];
                 this.state.selectedUsers.forEach((user) => {
-                    const newUser = nextProps.users.users
+                    const newUser = this.props.users.users
                         .find(nextUser => nextUser.user.username === user.user.username);
                     if (newUser) {
                         fixedSelection.push(newUser);
@@ -157,18 +157,18 @@ export class UserGroupsPage extends Component {
                 this.setState({ selectedUsers: fixedSelection });
             }
         }
-        if (nextProps.groups.updated && !this.props.groups.updated) {
+        if (this.props.groups.updated && !prevProps.groups.updated) {
             this.makeUserRequest();
             this.props.getGroups();
         }
-        if (nextProps.groups.created && !this.props.groups.created) {
+        if (this.props.groups.created && !prevProps.groups.created) {
             this.props.getGroups();
             if (this.state.createUsers.length) {
                 this.makeUserRequest();
                 this.setState({ createUsers: [] });
             }
         }
-        if (nextProps.groups.deleted && !this.props.groups.deleted) {
+        if (this.props.groups.deleted && !prevProps.groups.deleted) {
             this.props.getGroups();
             const query = { ...this.props.location.query };
             if (query.groups) {
@@ -180,11 +180,11 @@ export class UserGroupsPage extends Component {
                 query,
             });
         }
-        if (nextProps.groups.error && !this.props.groups.error) {
-            this.showErrorDialog(nextProps.groups.error);
+        if (this.props.groups.error && !prevProps.groups.error) {
+            this.showErrorDialog(this.props.groups.error);
         }
-        if (nextProps.users.error && !this.props.users.error) {
-            this.showErrorDialog(nextProps.users.error);
+        if (this.props.users.error && !prevProps.users.error) {
+            this.showErrorDialog(this.props.users.error);
         }
     }
 

--- a/eventkit_cloud/ui/static/ui/app/tests/Application.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/Application.spec.js
@@ -99,21 +99,6 @@ describe('Application component', () => {
         expect(drawer.find(MenuItem).at(6).find(Link)).toHaveLength(1);
     });
 
-    it('should call openDrawer when user data is added and window width is xl', () => {
-        const props = getProps();
-        props.userData = null;
-        props.openDrawer = sinon.spy();
-        const wrapper = getWrapper(props);
-        const nextProps = getProps();
-        nextProps.userData = { data: {} };
-        nextProps.width = 'xl';
-        const spy = sinon.spy(Application.prototype, 'componentWillReceiveProps');
-        wrapper.setProps(nextProps);
-        expect(spy.calledOnce).toBe(true);
-        expect(props.openDrawer.calledOnce).toBe(true);
-        spy.restore();
-    });
-
     it('should call getConfig, getNotifications, and addEventListener on mount', () => {
         const getStub = sinon.stub(Application.prototype, 'getConfig');
         const props = getProps();

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/BreadcrumbStepper.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/BreadcrumbStepper.spec.js
@@ -162,25 +162,22 @@ describe('BreadcrumbStepper component', () => {
         mountSpy.restore();
     });
 
-    it('componentWillReceiveProps should push to status page and clearJobInfo', () => {
+    it('componentDidUpdate should push to status page and clearJobInfo', () => {
         const props = getProps();
-        props.clearJobInfo = sinon.spy();
-        const hideStub = sinon.stub(BreadcrumbStepper.prototype, 'hideLoading');
         const pushStub = sinon.stub(browserHistory, 'push');
         const wrapper = getWrapper(props);
         const nextProps = { ...getProps() };
         nextProps.jobuid = '123';
         nextProps.jobFetched = true;
+        nextProps.clearJobInfo = sinon.spy();
         wrapper.setProps(nextProps);
-        expect(hideStub.calledOnce).toBe(true);
         expect(pushStub.calledOnce).toBe(true);
         expect(pushStub.calledWith('/status/123')).toBe(true);
-        expect(props.clearJobInfo.calledOnce).toBe(true);
-        hideStub.restore();
+        expect(nextProps.clearJobInfo.calledOnce).toBe(true);
         pushStub.restore();
     });
 
-    it('componentWillReceiveProps should show job error', () => {
+    it('componentDidUpdate should show job error', () => {
         const props = getProps();
         props.jobError = null;
         const hideStub = sinon.stub(BreadcrumbStepper.prototype, 'hideLoading');
@@ -190,7 +187,7 @@ describe('BreadcrumbStepper component', () => {
         const error = { errors: ['one', 'two'] };
         nextProps.jobError = error;
         wrapper.setProps(nextProps);
-        expect(hideStub.calledOnce).toBe(true);
+        expect(hideStub.called).toBe(true);
         expect(showErrorStub.calledOnce).toBe(true);
         expect(showErrorStub.calledWith(error)).toBe(true);
         hideStub.restore();

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportAOI.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportAOI.spec.js
@@ -80,6 +80,7 @@ describe('ExportAOI component', () => {
             onWalkthroughReset: () => {},
             updateAoiInfo: () => {},
             clearAoiInfo: () => {},
+            clearExportInfo: () => {},
             setNextDisabled: () => {},
             setNextEnabled: () => {},
             getGeocode: () => {},
@@ -237,20 +238,17 @@ describe('ExportAOI component', () => {
         updateMapSpy.restore();
     });
 
-    it('componentWillReceiveProps should handle geojson upload if processed', () => {
+    it('componentDidUpdate should handle geojson upload if processed', () => {
         const props = getProps();
-        const propsSpy = sinon.spy(ExportAOI.prototype, 'componentWillReceiveProps');
+        props.importGeom.processed = null;
         const wrapper = getWrapper(props);
-        wrapper.instance().handleGeoJSONUpload = sinon.spy();
-        wrapper.instance().updateAoiInfo = sinon.spy();
+        const uploadStub = sinon.stub(wrapper.instance(), 'handleGeoJSONUpload');
         const nextProps = getProps();
         nextProps.importGeom.processed = true;
         nextProps.importGeom.featureCollection = new Point([1, 1]);
         wrapper.setProps(nextProps);
-        expect(propsSpy.calledOnce).toBe(true);
-        expect(wrapper.instance().handleGeoJSONUpload.calledOnce).toBe(true);
-        expect(wrapper.instance().handleGeoJSONUpload.calledWith(nextProps.importGeom)).toBe(true);
-        propsSpy.restore();
+        expect(uploadStub.called).toBe(true);
+        expect(uploadStub.calledWith(nextProps.importGeom)).toBe(true);
     });
 
     it('setButtonSelected should update the specified icon state to SELECTED and all others to INACTIVE', () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/CreateDataPack/ExportInfo.spec.js
@@ -116,10 +116,10 @@ describe('ExportInfo component', () => {
         const joyrideSpy = sinon.spy(ExportInfo.prototype, 'joyrideAddSteps');
         getWrapper(props);
         expect(mountSpy.calledOnce).toBe(true);
-        expect(hasFieldsSpy.calledOnce).toBe(true);
+        expect(hasFieldsSpy.called).toBe(true);
         expect(hasFieldsSpy.calledWith(props.exportInfo)).toBe(true);
         expect(joyrideSpy.calledOnce).toBe(true);
-        expect(props.setNextDisabled.calledOnce).toBe(true);
+        expect(props.setNextDisabled.called).toBe(true);
         expect(props.updateExportInfo.calledWith({
             ...props.exportInfo,
             areaStr: expectedString,
@@ -131,30 +131,28 @@ describe('ExportInfo component', () => {
         joyrideSpy.restore();
     });
 
-    it('componentWillReceiveProps should setNextEnabled', () => {
+    it('componentDidUpdate should setNextEnabled', () => {
         const props = getProps();
-        props.setNextEnabled = sinon.spy();
         const wrapper = getWrapper(props);
-        expect(props.setNextEnabled.called).toBe(false);
         const nextProps = getProps();
+        nextProps.setNextEnabled = sinon.spy();
         nextProps.exportInfo.exportName = 'name';
         nextProps.exportInfo.datapackDescription = 'description';
         nextProps.exportInfo.projectName = 'project';
         nextProps.exportInfo.providers = [{}];
         nextProps.nextEnabled = false;
         wrapper.setProps(nextProps);
-        expect(props.setNextEnabled.calledOnce).toBe(true);
+        expect(nextProps.setNextEnabled.calledOnce).toBe(true);
     });
 
-    it('componentWillReceiveProps should setNextDisabled', () => {
+    it('componentDidUpdate should setNextDisabled', () => {
         const props = getProps();
-        props.setNextDisabled = sinon.spy();
         const wrapper = getWrapper(props);
-        expect(props.setNextDisabled.calledOnce).toBe(true);
         const nextProps = getProps();
+        nextProps.setNextDisabled = sinon.spy();
         nextProps.nextEnabled = true;
         wrapper.setProps(nextProps);
-        expect(props.setNextDisabled.calledTwice).toBe(true);
+        expect(nextProps.setNextDisabled.calledOnce).toBe(true);
     });
 
     it('onNameChange should call updateExportInfo', () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackPage.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/DataPackPage.spec.js
@@ -178,7 +178,7 @@ describe('DataPackPage component', () => {
         };
         const updateStub = sinon.stub(DataPackPage.prototype, 'updateLocationQuery');
         getWrapper(props);
-        expect(updateStub.calledOnce).toBe(true);
+        expect(updateStub.called).toBe(true);
         expect(updateStub.calledWith(expectedDefault)).toBe(true);
         updateStub.restore();
     });
@@ -199,7 +199,7 @@ describe('DataPackPage component', () => {
         props.runsMeta.view = 'grid';
         browserHistory.push.reset();
         const wrapper = getWrapper(props);
-        expect(browserHistory.push.calledOnce).toBe(true);
+        expect(browserHistory.push.called).toBe(true);
         expect(browserHistory.push.calledWith({
             ...props.location,
             query: {
@@ -212,7 +212,7 @@ describe('DataPackPage component', () => {
         browserHistory.push.reset();
         const nextProps = getProps();
         const nextWrapper = getWrapper(nextProps);
-        expect(browserHistory.push.calledOnce).toBe(true);
+        expect(browserHistory.push.called).toBe(true);
         expect(browserHistory.push.calledWith({
             ...nextProps.location,
             query: {

--- a/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/DataPackPage/MapView.spec.js
@@ -369,9 +369,9 @@ describe('MapView component', () => {
         MapView.prototype.addRunFeatures = addRunFeatures;
     });
 
-    it('componentWillReceiveProps should clear the source, re-add features, and fit runs extent when new features are received', () => {
+    it('componentDidUpdate should clear the source, re-add features, and fit runs extent when new features are received', () => {
         const props = getProps();
-        const receiveSpy = sinon.spy(MapView.prototype, 'componentWillReceiveProps');
+        const receiveSpy = sinon.spy(MapView.prototype, 'componentDidUpdate');
         const newSpy = sinon.spy(MapView.prototype, 'hasNewRuns');
         const wrapper = getWrapper(props);
         const clearSpy = sinon.spy(VectorSource.prototype, 'clear');
@@ -409,9 +409,9 @@ describe('MapView component', () => {
         fitSpy.restore();
     });
 
-    it('componentWillReceiveProps should clear the source, re-add features, and fit drawlayer extent', () => {
+    it('componentDidUpdate should clear the source, re-add features, and fit drawlayer extent', () => {
         const props = getProps();
-        const receiveSpy = sinon.spy(MapView.prototype, 'componentWillReceiveProps');
+        const receiveSpy = sinon.spy(MapView.prototype, 'componentDidUpdate');
         const newSpy = sinon.spy(MapView.prototype, 'hasNewRuns');
         const wrapper = getWrapper(props);
         const clearSpy = sinon.spy(VectorSource.prototype, 'clear');
@@ -450,7 +450,7 @@ describe('MapView component', () => {
         fitSpy.restore();
     });
 
-    it('componentWillReceiveProps should fit to runs extent if there is no draw layer', () => {
+    it('componentDidUpdate should fit to runs extent if there is no draw layer', () => {
         const props = getProps();
         const newSpy = sinon.spy(MapView.prototype, 'hasNewRuns');
         const wrapper = getWrapper(props);
@@ -487,7 +487,7 @@ describe('MapView component', () => {
         fitSpy.restore();
     });
 
-    it('componentWillReceiveProps should fit to draw layer no features are added', () => {
+    it('componentDidUpdate should fit to draw layer no features are added', () => {
         const props = getProps();
         const newSpy = sinon.spy(MapView.prototype, 'hasNewRuns');
         const wrapper = getWrapper(props);
@@ -521,7 +521,7 @@ describe('MapView component', () => {
         fitSpy.restore();
     });
 
-    it('componentWillReceiveProps should call zoomToFeature', () => {
+    it('componentDidUpdate should call zoomToFeature', () => {
         const props = getProps();
         const newStub = sinon.stub(MapView.prototype, 'hasNewRuns')
             .returns(true);
@@ -545,7 +545,7 @@ describe('MapView component', () => {
         zoomStub.restore();
     });
 
-    it('componentWillReceiveProps should call handleGeoJSONUpload', () => {
+    it('componentDidUpdate should call handleGeoJSONUpload', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         const nextProps = getProps();
@@ -564,7 +564,7 @@ describe('MapView component', () => {
         const wrapper = getWrapper(props);
         const updates = updateSpy.args.length;
         const mapUpdate = mapUpdateSpy.args.length;
-        wrapper.instance().componentDidUpdate();
+        wrapper.instance().componentDidUpdate(props);
         wrapper.update();
         expect(updateSpy.args.length).toEqual(updates + 1);
         expect(mapUpdateSpy.args.length).toEqual(mapUpdate + 1);

--- a/eventkit_cloud/ui/static/ui/app/tests/MapTools/DropZoneError.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/MapTools/DropZoneError.spec.js
@@ -39,15 +39,17 @@ describe('DropZoneError component', () => {
 
     it('should update state when new props are received', () => {
         const props = getProps();
-        props.setAllButtonsDefault = sinon.spy();
         const wrapper = getWrapper(props);
         const nextProps = getProps();
         nextProps.importGeom.error = 'An error has occured';
-        wrapper.instance().setState = sinon.spy();
+        nextProps.setAllButtonsDefault = sinon.spy();
+        const stateStub = sinon.stub(wrapper.instance(), 'setState');
         wrapper.setProps(nextProps);
-        expect(wrapper.instance().setState
-            .calledWith({ showErrorMessage: true, errorMessage: nextProps.importGeom.error })).toEqual(true);
-        expect(props.setAllButtonsDefault.calledOnce).toBe(true);
+        expect(stateStub.calledWith({
+            showErrorMessage: true,
+            errorMessage: nextProps.importGeom.error,
+        })).toEqual(true);
+        expect(nextProps.setAllButtonsDefault.calledOnce).toBe(true);
     });
 
     it('should not update state if new props have no error', () => {

--- a/eventkit_cloud/ui/static/ui/app/tests/MapTools/SearchAOIToolbar.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/MapTools/SearchAOIToolbar.spec.js
@@ -71,7 +71,10 @@ describe('SearchAOIToolbar button', () => {
         const suggestions = ['one', 'two'];
         const props = getProps();
         const wrapper = shallow(<SearchAOIToolbar {...props} />);
-        wrapper.setState({ suggestions });
+        const nextProps = getProps();
+        nextProps.geocode.fetched = true;
+        nextProps.geocode.data = suggestions;
+        wrapper.setProps(nextProps);
         expect(wrapper.state().suggestions).toEqual(suggestions);
         wrapper.instance().handleInputChange('e');
         expect(wrapper.state().suggestions.length).toEqual(0);
@@ -89,7 +92,10 @@ describe('SearchAOIToolbar button', () => {
         const suggestions = ['one', 'two'];
         const props = getProps();
         const wrapper = shallow(<SearchAOIToolbar {...props} />);
-        wrapper.setState({ suggestions });
+        const nextProps = getProps();
+        nextProps.geocode.fetched = true;
+        nextProps.geocode.data = suggestions;
+        wrapper.setProps(nextProps);
         expect(wrapper.state().suggestions).toEqual(suggestions);
         wrapper.instance().handleEnter('');
         expect(wrapper.state().suggestions.length).toEqual(0);

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/ProviderRow.spec.js
@@ -175,18 +175,16 @@ describe('ProviderRow component', () => {
         stateSpy.restore();
     });
 
-    it('componentWillReceiveProps should handle summing up the file sizes', () => {
+    it('componentDidUpdate should handle summing up the file sizes', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         const nextProps = getProps();
+        nextProps.provider.status = 'some new status';
         const fileSize = 1.234;
-        const propsSpy = sinon.spy(wrapper.instance(), 'componentWillReceiveProps');
         const stateSpy = sinon.spy(wrapper.instance(), 'setState');
         wrapper.setProps(nextProps);
-        expect(propsSpy.calledOnce).toBe(true);
         expect(stateSpy.calledWith({ fileSize: fileSize.toFixed(3) })).toBe(true);
         stateSpy.restore();
-        propsSpy.restore();
     });
 
     it('getTextFontSize should return the font string for table text based on window width', () => {
@@ -333,10 +331,10 @@ describe('ProviderRow component', () => {
 
     it('handleProviderOpen should set provider dialog to open', () => {
         const props = getProps();
-        const stateSpy = sinon.spy(ProviderRow.prototype, 'setState');
         const wrapper = shallow(<ProviderRow {...props} />);
+        const stateSpy = sinon.spy(wrapper.instance(), 'setState');
         wrapper.instance().handleProviderOpen();
-        expect(stateSpy.calledTwice).toBe(true);
+        expect(stateSpy.called).toBe(true);
         expect(stateSpy.calledWith({ providerDesc: 'provider description', providerDialogOpen: true })).toBe(true);
         wrapper.update();
         expect(wrapper.find(BaseDialog).childAt(0).text()).toEqual('provider description');
@@ -345,10 +343,10 @@ describe('ProviderRow component', () => {
 
     it('handleProviderClose should set the provider dialog to closed', () => {
         const props = getProps();
-        const stateSpy = sinon.spy(ProviderRow.prototype, 'setState');
         const wrapper = shallow(<ProviderRow {...props} />);
+        const stateSpy = sinon.spy(wrapper.instance(), 'setState');
         wrapper.instance().handleProviderClose();
-        expect(stateSpy.calledTwice).toBe(true);
+        expect(stateSpy.called).toBe(true);
         expect(stateSpy.calledWith({ providerDialogOpen: false })).toBe(true);
         stateSpy.restore();
     });

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/StatusDownload.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/StatusDownload.spec.js
@@ -250,7 +250,7 @@ describe('StatusDownload component', () => {
         joyrideSpy.restore();
     });
 
-    it('componentWillReceiveProps should call browserHistory push if a run has been deleted', () => {
+    it('componentDidUpdate should call browserHistory push if a run has been deleted', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         browserHistory.push = sinon.spy();
@@ -261,7 +261,7 @@ describe('StatusDownload component', () => {
         expect(browserHistory.push.calledWith('/exports')).toBe(true);
     });
 
-    it('componentWillReceiveProps should set error state on export rerun error', () => {
+    it('componentDidUpdate should set error state on export rerun error', () => {
         const props = getProps();
         const stateStub = sinon.stub(StatusDownload.prototype, 'setState');
         const wrapper = getWrapper(props);
@@ -273,46 +273,45 @@ describe('StatusDownload component', () => {
         stateStub.restore();
     });
 
-    it('componentWillReceiveProps should handle reRun of datacartDetails', () => {
+    it('componentDidUpdate should handle reRun of datacartDetails', () => {
         const props = getProps();
-        props.getDatacartDetails = sinon.spy();
         const timerStub = sinon.stub(StatusDownload.prototype, 'startTimer');
         const nextProps = getProps();
+        nextProps.getDatacartDetails = sinon.spy();
         nextProps.exportReRun.fetched = true;
         nextProps.exportReRun.data = [{ ...exampleRun }];
         const wrapper = getWrapper(props);
         wrapper.setProps(nextProps);
-        expect(props.getDatacartDetails.calledOnce).toBe(true);
+        expect(nextProps.getDatacartDetails.calledOnce).toBe(true);
         expect(timerStub.calledOnce).toBe(true);
         timerStub.restore();
     });
 
-    it('componentWillReceiveProps should handle expiration update', () => {
+    it('componentDidUpdate should handle expiration update', () => {
         const props = getProps();
-        props.getDatacartDetails = sinon.spy();
         const wrapper = getWrapper(props);
         const nextProps = getProps();
+        nextProps.getDatacartDetails = sinon.spy();
         nextProps.expirationState.updated = true;
         wrapper.setProps(nextProps);
-        expect(props.getDatacartDetails.calledOnce).toBe(true);
-        expect(props.getDatacartDetails.calledWith(props.router.params.jobuid)).toBe(true);
+        expect(nextProps.getDatacartDetails.calledOnce).toBe(true);
+        expect(nextProps.getDatacartDetails.calledWith(props.router.params.jobuid)).toBe(true);
     });
 
-    it('componentWillReceiveProps should handle permission update', () => {
+    it('componentDidUpdate should handle permission update', () => {
         const props = getProps();
-        props.getDatacartDetails = sinon.spy();
         const wrapper = getWrapper(props);
         const nextProps = getProps();
+        nextProps.getDatacartDetails = sinon.spy();
         nextProps.permissionState.updated = true;
         wrapper.setProps(nextProps);
-        expect(props.getDatacartDetails.calledOnce).toBe(true);
-        expect(props.getDatacartDetails.calledWith(props.router.params.jobuid)).toBe(true);
+        expect(nextProps.getDatacartDetails.calledOnce).toBe(true);
+        expect(nextProps.getDatacartDetails.calledWith(props.router.params.jobuid)).toBe(true);
     });
 
-    it('componentWillReceiveProps should handle fetched datacartDetails and set isLoading false', () => {
+    it('componentDidUpdate should handle fetched datacartDetails and set isLoading false', () => {
         jest.useFakeTimers();
         const props = getProps();
-        props.getDatacartDetails = sinon.spy();
         const stateStub = sinon.stub(StatusDownload.prototype, 'setState');
         const clearStub = sinon.stub(global.window, 'clearInterval');
         const wrapper = getWrapper(props);
@@ -320,6 +319,7 @@ describe('StatusDownload component', () => {
         const setStub = sinon.stub(global.window, 'setTimeout');
         setStub.onFirstCall().callsFake(callback => callback());
         const nextProps = getProps();
+        nextProps.getDatacartDetails = sinon.spy();
         nextProps.detailsFetched = true;
         nextProps.runs = [{ ...exampleRun }];
         nextProps.runIds = [exampleRun.uid];
@@ -329,13 +329,13 @@ describe('StatusDownload component', () => {
         expect(clearStub.calledOnce).toBe(true);
         expect(clearStub.calledWith(timer)).toBe(true);
         expect(setStub.called).toBe(true);
-        expect(props.getDatacartDetails.calledOnce).toBe(true);
+        expect(nextProps.getDatacartDetails.calledOnce).toBe(true);
         setStub.restore();
         stateStub.restore();
         clearStub.restore();
     });
 
-    it('componentWillReceiveProps should handle fetched datacartDetails and not clear interval zipfile_url is null', () => {
+    it('componentDidUpdate should handle fetched datacartDetails and not clear interval zipfile_url is null', () => {
         jest.useFakeTimers();
         const props = getProps();
         const clearStub = sinon.stub(global.window, 'clearInterval');
@@ -393,7 +393,7 @@ describe('StatusDownload component', () => {
         stateSpy.restore();
     });
 
-    it('componentWillReceiveProps should handle fetched datacartDetails and not clear interval when tasks are not completed', () => {
+    it('componentDidUpdate should handle fetched datacartDetails and not clear interval when tasks are not completed', () => {
         jest.useFakeTimers();
         const props = getProps();
         const clearStub = sinon.stub(global.window, 'clearInterval');
@@ -451,6 +451,7 @@ describe('StatusDownload component', () => {
         const wrapper = getWrapper(props);
         const error = [{ detail: 'one' }, { detail: 'two' }];
         wrapper.setState({ error });
+        wrapper.instance().forceUpdate();
         wrapper.update();
         const ret = wrapper.instance().getErrorMessage();
         expect(ret).toHaveLength(2);

--- a/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/UserGroupsPage.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/UserGroupsPage.spec.js
@@ -157,7 +157,7 @@ describe('UserGroupsPage component', () => {
         sinon.stub(UserGroupsPage.prototype, 'componentDidMount');
     });
 
-    it('componentWillReceiveProps should handle a query change', () => {
+    it('componentDidUpdate should handle a query change', () => {
         const props = getProps();
         props.location.query = { ordering: 'username', group: '2' };
         const requestStub = sinon.stub(UserGroupsPage.prototype, 'makeUserRequest');
@@ -175,7 +175,7 @@ describe('UserGroupsPage component', () => {
         requestStub.restore();
     });
 
-    it('componentWillReceiveProps should handle users fetched', () => {
+    it('componentDidUpdate should handle users fetched', () => {
         const props = getProps();
         const wrapper = getWrapper(props);
         wrapper.setState({ selectedUsers: [props.users.users[1], props.users.users[2]] });
@@ -189,7 +189,7 @@ describe('UserGroupsPage component', () => {
         stateStub.restore();
     });
 
-    it('componentWillReceiveProps should handle updated', () => {
+    it('componentDidUpdate should handle updated', () => {
         const props = getProps();
         props.getGroups = sinon.spy();
         const makeRequestStub = sinon.stub(UserGroupsPage.prototype, 'makeUserRequest');
@@ -202,7 +202,7 @@ describe('UserGroupsPage component', () => {
         makeRequestStub.restore();
     });
 
-    it('componentWillReceiveProps should handle created with no users', () => {
+    it('componentDidUpdate should handle created with no users', () => {
         const props = getProps();
         props.getGroups = sinon.spy();
         const makeRequestStub = sinon.stub(UserGroupsPage.prototype, 'makeUserRequest');
@@ -215,7 +215,7 @@ describe('UserGroupsPage component', () => {
         makeRequestStub.restore();
     });
 
-    it('componentWillReceiveProps should handle created with users', () => {
+    it('componentDidUpdate should handle created with users', () => {
         const props = getProps();
         props.getGroups = sinon.spy();
         const stateSpy = sinon.spy(UserGroupsPage.prototype, 'setState');
@@ -232,7 +232,7 @@ describe('UserGroupsPage component', () => {
         stateSpy.restore();
     });
 
-    it('componentWillReceiveProps should handle deleted', () => {
+    it('componentDidUpdate should handle deleted', () => {
         const props = getProps();
         props.location.query = { groups: '12' };
         props.getGroups = sinon.spy();
@@ -247,7 +247,7 @@ describe('UserGroupsPage component', () => {
         makeRequestStub.restore();
     });
 
-    it('componentWillReceiveProps should handle groups error', () => {
+    it('componentDidUpdate should handle groups error', () => {
         const props = getProps();
         const showStub = sinon.stub(UserGroupsPage.prototype, 'showErrorDialog');
         const wrapper = getWrapper(props);
@@ -257,7 +257,7 @@ describe('UserGroupsPage component', () => {
         showStub.restore();
     });
 
-    it('componentWillReceiveProps should handle users error', () => {
+    it('componentDidUpdate should handle users error', () => {
         const props = getProps();
         const showStub = sinon.stub(UserGroupsPage.prototype, 'showErrorDialog');
         const wrapper = getWrapper(props);


### PR DESCRIPTION
This PR fixes a bug with the providers not getting loaded in the ExportInfo page. Because the code was setup to work on a copy of the providers, the `props.providers` were assigned to the local `state` in the constructor and never updated. If you navigated to the ExportInfo step before the provider data was received from the API, the `props.providers` would be an empty list. To fix this a check has been added in `componentDidUpdate`. If new providers are detected we add them to state and run the provider checks.
I also broke some of the code up into smaller pieces so it would be more clear and easy to test.
The `setInterval` was removed because it didn't even work to begin with. The code could have been changed so that a working interval is set, but it does not seem like a necessary feature (the user has a refresh button).
You will also note that the ref logic has been removed from the CustomTextField. The ref was causing errors so some style logic has been added instead (which is a better way to do it regardless).

If you want to verify the changes, on master try cloning a job with the network performance on slow 3G or similar, when the AOI map loads immediately proceed to the ExportInfo step. You should see that the providers are initially empty, and do not load at all. If you repeat these steps on this branch, you should see the providers as initially empty, but then they will load in just a few seconds.

*no ui changes*