### PR TITLE
Resume mapproxy.

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -409,7 +409,7 @@ def osm_data_collection_pipeline(
     return geopackage_filepath
 
 
-@app.task(name="OSM (.gpkg)", bind=True, base=FormatTask, abort_on_error=True, acks_late=True)
+@app.task(name="OSM (.gpkg)", bind=True, base=FormatTask, abort_on_error=True)
 def osm_data_collection_task(
         self, result=None, stage_dir=None, run_uid=None, provider_slug=None, overpass_url=None, task_uid=None,
         job_name='no_job_name_specified', bbox=None, user_details=None,

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -409,7 +409,7 @@ def osm_data_collection_pipeline(
     return geopackage_filepath
 
 
-@app.task(name="OSM (.gpkg)", bind=True, base=FormatTask, abort_on_error=True)
+@app.task(name="OSM (.gpkg)", bind=True, base=FormatTask, abort_on_error=True, acks_late=True)
 def osm_data_collection_task(
         self, result=None, stage_dir=None, run_uid=None, provider_slug=None, overpass_url=None, task_uid=None,
         job_name='no_job_name_specified', bbox=None, user_details=None,
@@ -788,9 +788,9 @@ def bounds_export_task(self, result={}, run_uid=None, task_uid=None, stage_dir=N
 
 
 @app.task(name='Raster export (.gpkg)', bind=True, base=FormatTask, abort_on_error=True, acks_late=True)
-def external_raster_service_export_task(self, result=None, layer=None, config=None, run_uid=None, task_uid=None,
-                                        stage_dir=None, job_name=None, bbox=None, service_url=None, level_from=None,
-                                        level_to=None, name=None, service_type=None, *args, **kwargs):
+def mapproxy_export_task(self, result=None, layer=None, config=None, run_uid=None, task_uid=None,
+                         stage_dir=None, job_name=None, bbox=None, service_url=None, level_from=None,
+                         level_to=None, name=None, service_type=None, *args, **kwargs):
     """
     Class defining geopackage export for external raster service.
     """

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -787,7 +787,7 @@ def bounds_export_task(self, result={}, run_uid=None, task_uid=None, stage_dir=N
     return result
 
 
-@app.task(name='Raster export (.gpkg)', bind=True, base=FormatTask, abort_on_error=True)
+@app.task(name='Raster export (.gpkg)', bind=True, base=FormatTask, abort_on_error=True, acks_late=True)
 def external_raster_service_export_task(self, result=None, layer=None, config=None, run_uid=None, task_uid=None,
                                         stage_dir=None, job_name=None, bbox=None, service_url=None, level_from=None,
                                         level_to=None, name=None, service_type=None, *args, **kwargs):

--- a/eventkit_cloud/tasks/task_factory.py
+++ b/eventkit_cloud/tasks/task_factory.py
@@ -17,7 +17,7 @@ from eventkit_cloud.tasks.export_tasks import (finalize_export_provider_task, Ta
                                                wait_for_providers_task, create_zip_task, finalize_run_task,
                                                output_selection_geojson_task,
                                                osm_data_collection_task, wfs_export_task,
-                                               external_raster_service_export_task, wcs_export_task,
+                                               mapproxy_export_task, wcs_export_task,
                                                arcgis_feature_service_export_task)
 from eventkit_cloud.tasks import TaskStates
 from eventkit_cloud.tasks.helpers import get_run_staging_dir, get_provider_staging_dir, get_style_files
@@ -36,11 +36,11 @@ class TaskFactory:
     def __init__(self,):
         self.type_task_map = {'osm': osm_data_collection_task,
                               'wfs': wfs_export_task,
-                              'wms': external_raster_service_export_task,
+                              'wms': mapproxy_export_task,
                               'wcs': wcs_export_task,
-                              'wmts': external_raster_service_export_task,
-                              'tms': external_raster_service_export_task,
-                              'arcgis-raster': external_raster_service_export_task,
+                              'wmts': mapproxy_export_task,
+                              'tms': mapproxy_export_task,
+                              'arcgis-raster': mapproxy_export_task,
                               'arcgis-feature': arcgis_feature_service_export_task}
 
     def parse_tasks(self, worker=None, run_uid=None, user_details=None):

--- a/eventkit_cloud/tasks/tests/test_export_tasks.py
+++ b/eventkit_cloud/tasks/tests/test_export_tasks.py
@@ -20,7 +20,7 @@ from eventkit_cloud.celery import TaskPriority, app
 from eventkit_cloud.jobs.models import DatamodelPreset, Job
 from eventkit_cloud.tasks.export_tasks import (
     LockingTask, export_task_error_handler, finalize_run_task,
-    kml_export_task, external_raster_service_export_task, geopackage_export_task,
+    kml_export_task, mapproxy_export_task, geopackage_export_task,
     shp_export_task, arcgis_feature_service_export_task, update_progress,
     zip_files, pick_up_run_task, cancel_export_provider_task, kill_task, bounds_export_task, parse_result, finalize_export_provider_task,
     FormatTask, wait_for_providers_task, create_zip_task, default_format_time
@@ -252,11 +252,11 @@ class TestExportTasks(ExportTaskBase):
                                                                      slug=expected_provider_slug)
         saved_export_task = ExportTaskRecord.objects.create(export_provider_task=export_provider_task,
                                                             status=TaskStates.PENDING.value,
-                                                            name=external_raster_service_export_task.name)
-        external_raster_service_export_task.update_task_state(task_status=TaskStates.RUNNING.value,
-                                                             task_uid=str(saved_export_task.uid))
-        result = external_raster_service_export_task.run(run_uid=self.run.uid, task_uid=str(saved_export_task.uid), stage_dir=stage_dir,
-                                                         job_name=job_name)
+                                                            name=mapproxy_export_task.name)
+        mapproxy_export_task.update_task_state(task_status=TaskStates.RUNNING.value,
+                                               task_uid=str(saved_export_task.uid))
+        result = mapproxy_export_task.run(run_uid=self.run.uid, task_uid=str(saved_export_task.uid), stage_dir=stage_dir,
+                                          job_name=job_name)
         service_to_gpkg.convert.assert_called_once()
         mock_add_metadata_task.assert_called_once_with(result=result, job_uid=self.run.job.uid, provider_slug=expected_provider_slug)
         self.assertEqual(expected_output_path, result['result'])
@@ -266,8 +266,8 @@ class TestExportTasks(ExportTaskBase):
         self.assertEqual(TaskStates.RUNNING.value, run_task.status)
         service_to_gpkg.convert.side_effect = Exception("Task Failed")
         with self.assertRaises(Exception):
-            external_raster_service_export_task.run(run_uid=self.run.uid, task_uid=str(saved_export_task.uid), stage_dir=stage_dir,
-                                                    job_name=job_name)
+            mapproxy_export_task.run(run_uid=self.run.uid, task_uid=str(saved_export_task.uid), stage_dir=stage_dir,
+                                     job_name=job_name)
 
     def test_task_on_failure(self,):
         celery_uid = str(uuid.uuid4())

--- a/eventkit_cloud/tasks/tests/test_task_builders.py
+++ b/eventkit_cloud/tasks/tests/test_task_builders.py
@@ -14,7 +14,7 @@ from eventkit_cloud.tasks.task_factory import create_run
 from eventkit_cloud.tasks.task_builders import (
     TaskChainBuilder, create_export_task_record
 )
-from eventkit_cloud.tasks.export_tasks import osm_data_collection_task, external_raster_service_export_task, \
+from eventkit_cloud.tasks.export_tasks import osm_data_collection_task, mapproxy_export_task, \
     wcs_export_task
 
 logger = logging.getLogger(__name__)
@@ -78,7 +78,7 @@ class TestTaskBuilder(TestCase):
         task_chain_builder = TaskChainBuilder()
         # Even though code using pipes seems to be supported here it is throwing an error.
         try:
-            task_chain_builder.build_tasks(external_raster_service_export_task,
+            task_chain_builder.build_tasks(mapproxy_export_task,
                                            provider_task_uid=provider_task_record.uid, run=self.job.runs.first(),
                                            service_type='wms',
                                            worker="some_worker")

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -6,12 +6,14 @@ import yaml
 from django.conf import settings
 from django.db import connections
 import mapproxy
+from mapproxy.cache.geopackage import GeopackageCache
 from mapproxy.config.config import load_config, load_default_config
 from mapproxy.config.loader import ProxyConfiguration, ConfigurationError, validate_references
 from mapproxy.seed import seeder
 from mapproxy.seed.config import SeedingConfiguration
 from mapproxy.seed.seeder import seed
-from mapproxy.seed.util import ProgressLog, exp_backoff
+from mapproxy.seed.util import ProgressLog, exp_backoff, ProgressStore
+import os
 import sqlite3
 
 from eventkit_cloud.utils import auth_requests
@@ -49,6 +51,16 @@ def get_custom_exp_backoff(max_repeat=None):
         exp_backoff(*args, **kwargs)
 
     return custom_exp_backoff
+
+# This is a bug in mapproxy, https://github.com/mapproxy/mapproxy/issues/387
+def load_tile_metadata(self, tile):
+    if not self.supports_timestamp:
+        # GPKG specification does not include timestamps.
+        # This sets the timestamp of the tile to epoch (1970s)
+        tile.timestamp = -1
+    else:
+        self.load_tile(tile)
+
 
 
 class MapproxyGeopackage(object):
@@ -152,13 +164,18 @@ class MapproxyGeopackage(object):
         from eventkit_cloud.tasks.task_process import TaskProcess
 
         conf_dict, seed_configuration, mapproxy_configuration = self.get_check_config()
+        #  Customizations...
         mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(max_repeat=int(conf_dict.get('max_repeat', 5)))
+        mapproxy.cache.geopackage.GeopackageCache.load_tile_metadata = load_tile_metadata
         logger.info("Beginning seeding to {0}".format(self.gpkgfile))
         try:
             auth_requests.patch_https(self.name)
             auth_requests.patch_mapproxy_opener_cache(slug=self.name)
             check_service(conf_dict, self.name)
-            progress_logger = CustomLogger(verbose=True, task_uid=self.task_uid)
+
+            progress_store = get_progress_store(self.gpkgfile)
+            progress_logger = CustomLogger(verbose=True, task_uid=self.task_uid, progress_store=progress_store)
+            logger.error("ProgressStore {}".format(progress_logger.progress_store.filename))
             task_process = TaskProcess(task_uid=self.task_uid)
             task_process.start_process(billiard=True, target=seeder.seed,
                                        kwargs={"tasks": seed_configuration.seeds(['seed']),
@@ -175,6 +192,11 @@ class MapproxyGeopackage(object):
         finally:
             connections.close_all()
         return self.gpkgfile
+
+
+def get_progress_store(gpkg):
+    progress_file = os.path.join(os.path.dirname(gpkg), '.progress_logger')
+    return ProgressStore(filename=progress_file, continue_seed=True)
 
 
 def get_cache_template(sources, grids, geopackage, table_name='tiles'):

--- a/eventkit_cloud/utils/mapproxy.py
+++ b/eventkit_cloud/utils/mapproxy.py
@@ -162,7 +162,6 @@ class MapproxyGeopackage(object):
         """
 
         from eventkit_cloud.tasks.task_process import TaskProcess
-
         conf_dict, seed_configuration, mapproxy_configuration = self.get_check_config()
         #  Customizations...
         mapproxy.seed.seeder.exp_backoff = get_custom_exp_backoff(max_repeat=int(conf_dict.get('max_repeat', 5)))


### PR DESCRIPTION
This PR allows seeding of geopackages to continue if the celery worker is restarted. 

This is done by adding acks_late to the task which says that celery shouldn't acknowledge the task until the task is completed. 

To test create a raster export and then restart celery half way through, the job should completely finish, and the data should be in the geopackage.  

Please squash commits.