### PR TITLE
check and retry zipping files

### DIFF
--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -936,6 +936,7 @@ def finalize_export_provider_task(result=None, data_provider_task_uid=None,
     return result
 
 
+@gdalutils.retry
 def zip_files(include_files, file_path=None, static_files=None, *args, **kwargs):
     """
     Contains the organization for the files within the archive.
@@ -1015,6 +1016,9 @@ def zip_files(include_files, file_path=None, static_files=None, *args, **kwargs)
                 filepath,
                 arcname=filename
             )
+        
+        if zipfile.testzip():
+            raise Exception("The zipped file was corrupted.")
 
     return file_path
 

--- a/eventkit_cloud/tasks/helpers.py
+++ b/eventkit_cloud/tasks/helpers.py
@@ -1,18 +1,18 @@
 import os
 import re
 
-import codecs
 import copy
 from contextlib import contextmanager
 
 from django.conf import settings
-from django.template import Context
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.db.models import Q
 
 from enum import Enum
 from numpy import linspace
+
+from eventkit_cloud.tasks import logger
 from eventkit_cloud.ui.helpers import logger
 from eventkit_cloud.utils import auth_requests
 from eventkit_cloud.utils.gdalutils import get_band_statistics
@@ -204,8 +204,6 @@ def get_human_readable_metadata_document(metadata):
     :param metadata: A dictionary returned by get_metadata.
     :return: A filepath to a txt document.
     """
-    from eventkit_cloud.tasks.models import ExportRun
-    from eventkit_cloud.jobs.models import DataProvider
     from eventkit_cloud.tasks.helpers import normalize_name
     stage_dir = os.path.join(settings.EXPORT_STAGING_ROOT, str(metadata['run_uid']))
 


### PR DESCRIPTION
Tries to rezip files if the zipfile is corrupted. 

To test, ensure that files still zip normally.