### PR TITLE
EVK-207 fix issue with dialog being duplicated

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
+++ b/eventkit_cloud/ui/static/ui/app/components/StatusDownloadPage/DataPackGeneralTable.js
@@ -75,27 +75,29 @@ export class DataPackGeneralTable extends Component {
                     title="Data Sources"
                     dataStyle={{ flexWrap: 'wrap', padding: '5px 10px 5px', display: 'grid' }}
                     data={
-                        providerTasks.map(providerTask => (
-                            <div key={providerTask.name} style={{ margin: '5px 0px' }}>
-                                {providerTask.name}
-                                <Info
-                                    className="qa-DataPackGeneralTable-Info-source"
-                                    onClick={() => this.handleProviderOpen(providerTask)}
-                                    key={providerTask.description}
-                                    style={styles.tableRowInfoIcon}
-                                />
-                                <BaseDialog
-                                    className="qa-DataPackGeneralTable-BaseDialog-source"
-                                    show={this.state.providerDialogOpen}
-                                    title={this.state.providerName}
-                                    onClose={this.handleProviderClose}
-                                >
-                                    <div style={{ paddingTop: '20px', wordWrap: 'break-word' }}>
-                                        {this.state.providerDescription}
-                                    </div>
-                                </BaseDialog>
-                            </div>
-                        ))
+                        <div>
+                            {providerTasks.map(providerTask => (
+                                <div key={providerTask.name} style={{ margin: '5px 0px' }}>
+                                    {providerTask.name}
+                                    <Info
+                                        className="qa-DataPackGeneralTable-Info-source"
+                                        onClick={() => this.handleProviderOpen(providerTask)}
+                                        key={providerTask.description}
+                                        style={styles.tableRowInfoIcon}
+                                    />
+                                </div>
+                            ))}
+                            <BaseDialog
+                                className="qa-DataPackGeneralTable-BaseDialog-source"
+                                show={this.state.providerDialogOpen}
+                                title={this.state.providerName}
+                                onClose={this.handleProviderClose}
+                            >
+                                <div style={{ paddingTop: '20px', wordWrap: 'break-word' }}>
+                                    {this.state.providerDescription}
+                                </div>
+                            </BaseDialog>
+                        </div>
                     }
                 />
                 <CustomTableRow

--- a/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackGeneralTable.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/StatusDownloadPage/DataPackGeneralTable.spec.js
@@ -66,7 +66,7 @@ describe('DataPackGeneralTable component', () => {
         const props = getProps();
         const openStub = sinon.stub(DataPackGeneralTable.prototype, 'handleProviderOpen');
         const wrapper = getWrapper(props);
-        shallow(wrapper.find(CustomTableRow).at(2).props().data[0])
+        shallow(wrapper.find(CustomTableRow).at(2).props().data)
             .find('.qa-DataPackGeneralTable-Info-source').simulate('click');
         expect(openStub.calledOnce).toBe(true);
         openStub.restore();


### PR DESCRIPTION
This PR fixes an issue with the data providers dialog on status & download page. The dialog was being added and shown for each provider, so if there were 5 providers you would actually have 5 dialogs showing on open. This caused the backdrop to be darker than it should be. Now only one dialog will show and it should have the proper backdrop opacity/color.