### PR TITLE
EVK-212 Hide Appbar icons when logged out

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/tests/Application.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/Application.spec.js
@@ -124,7 +124,7 @@ describe('Application component', () => {
         expect(props.closeDrawer.callCount).toBe(1);
         wrapper.setProps({ ...props, drawer: 'closed' });
         wrapper.instance().handleToggle();
-        expect(props.openDrawer.callCount).toBe(2);
+        expect(props.openDrawer.callCount).toBe(1);
     });
 
     it('onMenuItemClick should call handleToggle if screen size is smaller than 1200', () => {


### PR DESCRIPTION
This PR fixes a regression with the drawer and notification button visibility. The buttons (at the top left of the page) should be hidden when user is not logged in.
*no real ui changes, just make sure drawer and notification icons are hidden when not logged in*