### PR TITLE
EVK-214 ui logging

### DIFF
--- a/config/ui/webpack.config.js
+++ b/config/ui/webpack.config.js
@@ -6,6 +6,7 @@ var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlug
 var CompressionPlugin = require('compression-webpack-plugin');
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
 var CleanWebpackPlugin = require('clean-webpack-plugin');
+var UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 var BASE_DIR = path.resolve('eventkit_cloud', 'ui', 'static', 'ui')
 var BUILD_DIR = path.resolve(BASE_DIR, 'build');
@@ -106,6 +107,15 @@ var config = {
         ],
     },
     optimization: {
+        minimizer: [
+            new UglifyJsPlugin({
+                uglifyOptions: {
+                    compress: {
+                        drop_console: true,
+                    }
+                }
+            })
+        ],
         splitChunks: {
             cacheGroups: {
                 commons: {

--- a/eventkit_cloud/ui/static/ui/app/actions/datapackActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/datapackActions.js
@@ -193,7 +193,7 @@ export function getRuns(args = {}) {
             // dispatch();
         }).catch((error) => {
             if (axios.isCancel(error)) {
-                console.log(error.message);
+                console.warn(error.message);
             } else {
                 dispatch(makeAuthRequired({ type: types.FETCH_RUNS_ERROR, error: error.response.data }));
             }
@@ -279,7 +279,7 @@ export function getFeaturedRuns(args) {
             ]);
         }).catch((error) => {
             if (axios.isCancel(error)) {
-                console.log(error.message);
+                console.warn(error.message);
             } else {
                 dispatch(makeAuthRequired({ type: types.FETCH_FEATURED_RUNS_ERROR, error: error.response.data }));
             }

--- a/eventkit_cloud/ui/static/ui/app/actions/formatActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/formatActions.js
@@ -20,7 +20,7 @@ export function getFormats() {
                 formats: response.data,
             }));
         }).catch((error) => {
-            console.log(error);
+            console.warn(error);
         });
     };
 }

--- a/eventkit_cloud/ui/static/ui/app/actions/geocodeActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/geocodeActions.js
@@ -43,7 +43,7 @@ export function getGeocode(query) {
             })
             .catch((e) => {
                 if (axios.isCancel(e)) {
-                    console.log(e.message);
+                    console.warn(e.message);
                 } else {
                     let error = e.response.data;
                     if (!error) {

--- a/eventkit_cloud/ui/static/ui/app/actions/groupActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/groupActions.js
@@ -42,7 +42,7 @@ export function getGroups() {
             dispatch(makeAuthRequired({ type: types.FETCHED_GROUPS, groups: response.data }));
         }).catch((error) => {
             if (axios.isCancel(error)) {
-                console.log(error.message);
+                console.warn(error.message);
             } else {
                 dispatch(makeAuthRequired({ type: types.FETCH_GROUPS_ERROR, error: error.response.data }));
             }

--- a/eventkit_cloud/ui/static/ui/app/actions/notificationsActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/notificationsActions.js
@@ -78,7 +78,7 @@ export function getNotifications(args = {}) {
             }));
         }).catch((error) => {
             if (axios.isCancel(error)) {
-                console.log(error.message);
+                console.warn(error.message);
             } else {
                 dispatch(makeAuthRequired({
                     type: types.FETCH_NOTIFICATIONS_ERROR,
@@ -267,7 +267,7 @@ export function getNotificationsUnreadCount(args = {}) {
             }));
         }).catch((error) => {
             if (axios.isCancel(error)) {
-                console.log(error.message);
+                console.warn(error.message);
             } else {
                 dispatch(makeAuthRequired({
                     type: types.FETCH_NOTIFICATIONS_UNREAD_COUNT_ERROR,

--- a/eventkit_cloud/ui/static/ui/app/actions/providerActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/providerActions.js
@@ -24,7 +24,7 @@ export function getProviders() {
                 providers: response.data,
             }));
         }).catch((error) => {
-            console.log(error);
+            console.warn(error);
         });
     };
 }

--- a/eventkit_cloud/ui/static/ui/app/actions/userActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActions.js
@@ -26,7 +26,7 @@ export function logout() {
                 dispatch(resetState());
             }
         }).catch((error) => {
-            console.log(error);
+            console.warn(error);
         })
     );
 }
@@ -113,7 +113,7 @@ export function userActive() {
                 },
             });
         }).catch((error) => {
-            console.error(error.message);
+            console.warn(error.message);
         })
     );
 }

--- a/eventkit_cloud/ui/static/ui/app/actions/userActivityActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActivityActions.js
@@ -30,7 +30,6 @@ export function viewedJob(jobuid) {
                 jobuid,
             }));
         }).catch((error) => {
-            console.error(error.message);
             dispatch(makeAuthRequired({
                 type: types.VIEWED_JOB_ERROR,
                 jobuid,
@@ -120,7 +119,7 @@ export function getViewedJobs(args = {}) {
             ]);
         }).catch((error) => {
             if (axios.isCancel(error)) {
-                console.log(error.message);
+                console.warn(error.message);
             } else {
                 dispatch(makeAuthRequired({
                     type: types.FETCH_VIEWED_JOBS_ERROR,

--- a/eventkit_cloud/ui/static/ui/app/actions/userActivityActions.js
+++ b/eventkit_cloud/ui/static/ui/app/actions/userActivityActions.js
@@ -29,7 +29,7 @@ export function viewedJob(jobuid) {
                 type: types.VIEWED_JOB_SUCCESS,
                 jobuid,
             }));
-        }).catch((error) => {
+        }).catch(() => {
             dispatch(makeAuthRequired({
                 type: types.VIEWED_JOB_ERROR,
                 jobuid,

--- a/eventkit_cloud/ui/static/ui/app/components/Application.tsx
+++ b/eventkit_cloud/ui/static/ui/app/components/Application.tsx
@@ -360,7 +360,7 @@ export class Application extends React.Component<Props, State> {
                     this.setState({ childContext: { config: response.data } });
                 }
             }).catch((error) => {
-                console.log(error.response.data);
+                console.warn(error.response.data);
             });
     }
 

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -241,10 +241,9 @@ export class ExportAOI extends Component {
                 },
             }).then(response => (
                 this.handleSearch(response.data)
-            )).catch((error) => {
-                console.log(error.message);
-                return this.handleSearch(result);
-            });
+            )).catch(() => (
+                this.handleSearch(result)
+            ));
         }
         return this.handleSearch(result);
     }

--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportInfo.js
@@ -193,8 +193,7 @@ export class ExportInfo extends React.Component {
             newProvider.availability = JSON.parse(response.data);
             newProvider.availability.slug = provider.slug;
             return newProvider;
-        }).catch((error) => {
-            console.error(error);
+        }).catch(() => {
             newProvider.availability = {
                 status: 'WARN',
                 type: 'CHECK_FAILURE',

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/FilterHeader.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/FilterHeader.js
@@ -30,7 +30,7 @@ export class FilterHeader extends Component {
                     className="qa-FilterHeader-Button-clear"
                     style={{ minWidth: 'none', textTransform: 'none' }}
                     color="primary"
-                    variant="flat"
+                    variant="text"
                     onClick={this.props.onClear}
                 >
                     Clear All

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -622,10 +622,9 @@ export class MapView extends Component {
                 },
             }).then(response => (
                 this.handleSearch(response.data)
-            )).catch((error) => {
-                console.log(error.message);
-                return this.handleSearch(result);
-            });
+            )).catch(() => (
+                this.handleSearch(result)
+            ));
         }
         return this.handleSearch(result);
     }

--- a/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationMessage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/Notification/NotificationMessage.js
@@ -115,7 +115,7 @@ export class NotificationMessage extends Component {
                 break;
             }
             default: {
-                console.error(`Unsupported notification verb '${verb}'`, notification);
+                console.warn(`Unsupported notification verb '${verb}'`, notification);
                 return null;
             }
         }

--- a/eventkit_cloud/ui/static/ui/app/components/NotificationsPage/NotificationsPage.js
+++ b/eventkit_cloud/ui/static/ui/app/components/NotificationsPage/NotificationsPage.js
@@ -148,7 +148,7 @@ export class NotificationsPage extends React.Component {
                                 <div className="qa-NotificationsPage-Content-Notifications">
                                     {isWidthUp('md', this.props.width) ?
                                         <NotificationsTable
-                                            notifications={this.props.notificationsData}
+                                            notificationsData={this.props.notificationsData}
                                             notificationsArray={notifications}
                                             router={this.props.router}
                                         />

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/OwnUserRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/OwnUserRow.js
@@ -169,8 +169,8 @@ export class OwnUserRow extends Component {
 
 OwnUserRow.defaultProps = {
     isAdmin: false,
-    handleDemoteAdmin: () => { console.error('Demote admin function not provided'); },
-    handleRemoveUser: () => { console.error('Remove user function not provided'); },
+    handleDemoteAdmin: () => { console.warn('Demote admin function not provided'); },
+    handleRemoveUser: () => { console.warn('Remove user function not provided'); },
     showAdminButton: false,
     showAdminLabel: false,
     showRemoveButton: false,

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserHeader.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserHeader.js
@@ -256,8 +256,8 @@ export class UserHeader extends Component {
 }
 
 UserHeader.defaultProps = {
-    handleRemoveUsers: () => { console.error('No remove users handler supplied'); },
-    handleAdminRights: () => { console.error('No admin rights handler supplied'); },
+    handleRemoveUsers: () => { console.warn('No remove users handler supplied'); },
+    handleAdminRights: () => { console.warn('No admin rights handler supplied'); },
     selectedGroup: null,
     showRemoveButton: false,
     showAdminButton: false,

--- a/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserRow.js
+++ b/eventkit_cloud/ui/static/ui/app/components/UserGroupsPage/UserRow.js
@@ -209,9 +209,9 @@ export class UserRow extends Component {
 }
 
 UserRow.defaultProps = {
-    handleMakeAdmin: () => { console.error('Make admin function not provided'); },
-    handleDemoteAdmin: () => { console.error('Demote admin function not provided'); },
-    handleRemoveUser: () => { console.error('Remove user function not provided'); },
+    handleMakeAdmin: () => { console.warn('Make admin function not provided'); },
+    handleDemoteAdmin: () => { console.warn('Demote admin function not provided'); },
+    handleRemoveUser: () => { console.warn('Remove user function not provided'); },
     isAdmin: false,
     showAdminButton: false,
     showAdminLabel: false,

--- a/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/OwnUserRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/OwnUserRow.spec.js
@@ -87,7 +87,7 @@ describe('OwnUserRow component', () => {
     });
 
     it('demote admin and remove user should log a warning if functions are not supplied', () => {
-        const consoleStub = sinon.stub(console, 'error');
+        const consoleStub = sinon.stub(console, 'warn');
         const props = getProps();
         const wrapper = getWrapper(props);
         const e = { stopPropagation: sinon.spy() };

--- a/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/UserRow.spec.js
+++ b/eventkit_cloud/ui/static/ui/app/tests/UserGroupsPage/UserRow.spec.js
@@ -116,7 +116,7 @@ describe('UserRow component', () => {
     });
 
     it('make and demote admin and remove user should log a warning if functions are not supplied', () => {
-        const consoleStub = sinon.stub(console, 'error');
+        const consoleStub = sinon.stub(console, 'warn');
         const props = getProps();
         const wrapper = getWrapper(props);
         const e = { stopPropagation: sinon.spy() };


### PR DESCRIPTION
This PR updates our ui logs.
In a few places I removed unneeded log statements.
Most logs were switched to 'warn'.
(we log primarily for cancelled api requests, response error that are not handled in any way, and unauthorized actions)
Console was disabled for production.
If we ever add logs that are helpful in production we can switch to disabling specific log levels 
but as it is we dont need any of the logs in prod.
*no ui changes, just check the production build to verify no noisy logs are being produced*