### PR TITLE
EVK-210 separate queues

### DIFF
--- a/eventkit_cloud/celery.py
+++ b/eventkit_cloud/celery.py
@@ -7,10 +7,10 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'eventkit_cloud.settings.prod')
 
 
 class TaskPriority(Enum):
-    CANCEL = 80                 # If cancel isn't higher than new tasks, long running processes will needlessly
+    CANCEL = 99                 # If cancel isn't higher than new tasks, long running processes will needlessly
                                 # take resources while the cancel message is blocked.
-    FINALIZE_RUN = 70           # If a run is finished it should be cleaned up before starting new tasks.
-    FINALIZE_PROVIDER = 60      # It is better to finalize a previous task before starting a new one so that the
+    FINALIZE_RUN = 90           # If a run is finished it should be cleaned up before starting new tasks.
+    FINALIZE_PROVIDER = 80      # It is better to finalize a previous task before starting a new one so that the
                                 # processed file is made available to the user.
     RUN_TASK = 50            # Running tasks should be higher than picking up tasks
     DEFAULT = 0                 # The default task priority in RabbitMQ is zero, so not having a priority is the same as

--- a/eventkit_cloud/tasks/export_tasks.py
+++ b/eventkit_cloud/tasks/export_tasks.py
@@ -848,7 +848,7 @@ def pick_up_run_task(self, result=None, run_uid=None, user_details=None, *args, 
 
 
 # This could be improved by using Redis or Memcached to help manage state.
-@app.task(name='Wait For Providers', base=UserDetailsBase)
+@app.task(name='Wait For Providers', base=UserDetailsBase, acks_late=True)
 def wait_for_providers_task(result=None, apply_args=None, run_uid=None, callback_task=None, *args, **kwargs):
     from eventkit_cloud.tasks.models import ExportRun
 
@@ -867,7 +867,7 @@ def wait_for_providers_task(result=None, apply_args=None, run_uid=None, callback
         raise Exception("A run could not be found for uid {0}".format(run_uid))
 
 
-@app.task(name='Project File (.zip)', base=FormatTask)
+@app.task(name='Project File (.zip)', base=FormatTask, acks_late=True)
 def create_zip_task(result=None, data_provider_task_uid=None, *args, **kwargs):
     """
     :param result: The celery task result value, it should be a dict with the current state.

--- a/eventkit_cloud/tasks/task_builders.py
+++ b/eventkit_cloud/tasks/task_builders.py
@@ -118,6 +118,11 @@ class TaskChainBuilder(object):
             display=getattr(primary_export_task, "display", False)
         )
 
+        if "osm" in primary_export_task.name.lower():
+            queue_routing_key_name = "{}.osm".format(worker)
+        else:
+            queue_routing_key_name = worker
+
         primary_export_task_signature = primary_export_task.s(name=provider_task.provider.slug,
                                                               run_uid=run.uid,
                                                               provider_slug=provider_task.provider.slug,
@@ -135,8 +140,9 @@ class TaskChainBuilder(object):
                                                               level_to=provider_task.provider.level_to,
                                                               service_type=service_type,
                                                               service_url=provider_task.provider.url,
-                                                              config=provider_task.provider.config).set(queue=worker,
-                                                                                                routing_key=worker)
+                                                              config=provider_task.provider.config).set(queue=queue_routing_key_name,
+                                                                                                        routing_key=queue_routing_key_name)
+
 
         if format_tasks:
             tasks = chain(primary_export_task_signature, format_tasks)

--- a/eventkit_cloud/tasks/task_factory.py
+++ b/eventkit_cloud/tasks/task_factory.py
@@ -89,8 +89,13 @@ class TaskFactory:
             run_dir = get_run_staging_dir(run.uid)
             os.makedirs(run_dir, 0o750)
 
+            wait_for_providers_settings = {
+                'queue': "{}.finalize".format(worker), 'routing_key': "{}.finalize".format(worker),
+                'priority': TaskPriority.FINALIZE_PROVIDER.value}
+
             finalize_task_settings = {
-                'interval': 4, 'max_retries': 10, 'queue': worker, 'routing_key': worker,
+                'interval': 4, 'max_retries': 10, 'queue': "{}.finalize".format(worker),
+                'routing_key': "{}.finalize".format(worker),
                 'priority': TaskPriority.FINALIZE_RUN.value}
 
             finalized_provider_task_chain_list = []
@@ -133,7 +138,7 @@ class TaskFactory:
                         run_uid=run_uid,
                         locking_task_key=run_uid,
                         callback_task=create_finalize_run_task_collection(run_uid, run_dir, run_zip_task_chain, apply_args=finalize_task_settings),
-                        apply_args=finalize_task_settings).set(**finalize_task_settings)
+                        apply_args=finalize_task_settings).set(**wait_for_providers_settings)
 
                     if provider_subtask_chain:
                         # The finalize_export_provider_task will check all of the export tasks

--- a/scripts/get_metrics.py
+++ b/scripts/get_metrics.py
@@ -1,0 +1,48 @@
+from eventkit_cloud.tasks.models import ExportRun
+from datetime import timedelta, datetime
+
+
+def meters_to_sq_km(meters):
+    return meters / 1000000
+
+
+def get_duration(time_tracking_model):
+    """
+    The duration in seconds
+    :param time_tracking_model: A model that has finished_at and started_at properties.
+    :return: Time in seconds (float).
+    """
+
+    time = (getattr(time_tracking_model, 'finished_at', datetime(0)) - getattr(time_tracking_model, 'started_at',
+                                                                                datetime(0))).seconds
+    if time:
+        return time
+
+
+def get_averages(run_uids=None):
+    if run_uids:
+        runs = ExportRun.objects.filter(uids__in=run_uids)
+    else:
+        runs = ExportRun.objects.all()
+
+    # optimize
+    runs = runs.select_related('user').prefetch_related('job__provider_tasks__provider',
+                                                        'job__provider_tasks__formats',
+                                                        'provider_tasks__tasks__result',
+                                                        'provider_tasks__tasks__exceptions')
+
+    times = {}
+    for run in runs:
+        area = meters_to_sq_km(run.job.the_geom_webmercator.area)
+        for provider_task in run.provider_tasks.all():
+            if not times.get(provider_task.slug):
+                times[provider_task.slug] = []
+            # Seconds per kilometer
+            duration = get_duration(provider_task)
+            if duration:
+                times[provider_task.slug] += [duration/area]
+
+    for provider_task, times in times.items():
+        print(provider_task)
+        print(str(timedelta(seconds=sum(times))))
+

--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-celery worker -A eventkit_cloud --concurrency=$$CONCURRENCY --loglevel=$$LOG_LEVEL -n worker@%h -Q $$HOSTNAME & \
-celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n celery@%h -Q celery & \
-celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n cancel@%h -Q $$HOSTNAME.cancel & \
-celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n finalize@%h -Q $$HOSTNAME.finalize & \
-celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n osm@%h -Q $$HOSTNAME.osm
+celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $HOSTNAME & \
+celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
+celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel & \
+celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n finalize@%h -Q $HOSTNAME.finalize & \
+celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n osm@%h -Q $HOSTNAME.osm

--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-celery worker -A eventkit_cloud --concurrency=$CONCURRENCY --loglevel=$LOG_LEVEL -n worker@%h -Q $HOSTNAME & \
-celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n celery@%h -Q celery & \
-celery worker -A eventkit_cloud --loglevel=$LOG_LEVEL -n cancel@%h -Q $HOSTNAME.cancel
+celery worker -A eventkit_cloud --concurrency=$$CONCURRENCY --loglevel=$$LOG_LEVEL -n worker@%h -Q $$HOSTNAME & \
+celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n celery@%h -Q celery & \
+celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n cancel@%h -Q $$HOSTNAME.cancel & \
+celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n finalize@%h -Q $$HOSTNAME.finalize & \
+celery worker -A eventkit_cloud --loglevel=$$LOG_LEVEL -n osm@%h -Q $$HOSTNAME.osm


### PR DESCRIPTION
This separates OSM data and the finalize tasks into their own queues.  This ensures that the running containers/VM has enough memory to process the osm data, and ensures that finalizing a task does not get blocked behind other tasks. 

To test this PR requires the conda artifact and eventkit containers to be rebuilt.
```
cd ./conda/; dc run --rm conda ./build.sh eventkit-cloud; cd ..; dc build eventkit; dc up -d; dc logs -f celery
```
Then ensure that after running an osm export that the correct tasks were passed to the correct queues (i.e. cloud.eventkit.test:49555)