### PR TITLE
EVK-220 remove deleted runs in redux

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -280,12 +280,16 @@ export class MapView extends Component {
 
     // helper function that changes feature style to unselected
     setFeatureNotSelected(unselectedFeature) {
-        unselectedFeature.setStyle(this.defaultStyleFunction);
+        if (unselectedFeature) {
+            unselectedFeature.setStyle(this.defaultStyleFunction);
+        }
     }
 
     // helper function that changes feature style to selected
     setFeatureSelected(selectedFeature) {
-        selectedFeature.setStyle(this.selectedStyleFunction);
+        if (selectedFeature) {
+            selectedFeature.setStyle(this.selectedStyleFunction);
+        }
     }
 
     setButtonSelected(iconName) {

--- a/eventkit_cloud/ui/static/ui/app/reducers/datapackReducer.js
+++ b/eventkit_cloud/ui/static/ui/app/reducers/datapackReducer.js
@@ -41,6 +41,16 @@ const addRun = (state, run) => {
     return { ...state, [run.uid]: run };
 };
 
+const removeRun = (state, id) => {
+    if (state[id]) {
+        const newState = { ...state };
+        newState[id] = null;
+        delete newState[id];
+        return newState;
+    }
+    return state;
+};
+
 const addJob = (state, job) => {
     if (isEqual(state[job.uid], job)) {
         return state;
@@ -120,6 +130,9 @@ const runsById = (state = exports.data.runs, action) => {
                 state,
                 Object.values(action.payload.runs || {})[0],
             );
+        }
+        case types.DELETED_RUN: {
+            return removeRun(state, action.payload.id);
         }
         default: return state;
     }


### PR DESCRIPTION
This PR fixes an issue with the DataPackLibrary map still showing runs after they were deleted.
To test, make sure when you delete a run it is also removed from the map.