### PR TITLE
EVK-223 fix zoom level update

### DIFF
--- a/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
+++ b/eventkit_cloud/ui/static/ui/app/components/CreateDataPack/ExportAOI.js
@@ -487,11 +487,14 @@ export class ExportAOI extends Component {
         this.map.addLayer(this.bufferLayer);
 
         this.updateZoomLevel();
-        this.map.getView().on('propertychange', this.updateZoomLevel);
+        this.map.getView().on('change:resolution', this.updateZoomLevel);
     }
 
     updateZoomLevel() {
-        this.setState({ zoomLevel: this.map.getView().getZoom() });
+        const lvl = Math.floor(this.map.getView().getZoom());
+        if (lvl !== this.state.zoomLevel) {
+            this.setState({ zoomLevel: lvl });
+        }
     }
 
     upEvent() {

--- a/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
+++ b/eventkit_cloud/ui/static/ui/app/components/DataPackPage/MapView.js
@@ -171,7 +171,7 @@ export class MapView extends Component {
         this.clickListener = this.map.on('singleclick', this.onMapClick);
 
         this.updateZoomLevel();
-        this.map.getView().on('propertychange', this.updateZoomLevel);
+        this.map.getView().on('change:resolution', this.updateZoomLevel);
     }
 
     componentDidUpdate(prevProps) {
@@ -328,7 +328,10 @@ export class MapView extends Component {
     }
 
     updateZoomLevel() {
-        this.setState({ zoomLevel: this.map.getView().getZoom() });
+        const lvl = Math.floor(this.map.getView().getZoom());
+        if (lvl !== this.state.zoomLevel) {
+            this.setState({ zoomLevel: lvl });
+        }
     }
 
     hasNewRuns(prevRuns, nextRuns) {

--- a/eventkit_cloud/ui/static/ui/app/components/MapTools/ZoomLevelLabel.js
+++ b/eventkit_cloud/ui/static/ui/app/components/MapTools/ZoomLevelLabel.js
@@ -4,10 +4,8 @@ import css from '../../styles/ol3map.css';
 
 export class ZoomLevelLabel extends Component {
     render() {
-        const zoomLevel = Math.floor(this.props.zoomLevel);
-
         return (
-            <div className={css.olZoomLevel}>Zoom Level: {zoomLevel}</div>
+            <div className={css.olZoomLevel}>Zoom Level: {this.props.zoomLevel}</div>
         );
     }
 }


### PR DESCRIPTION
This PR fixes an issue with the zoom level update function causing poor zoom/pan performance. The function was being added as the callback of a listener to ol/View `propertychange` events and called `setState` every single time without checking for changes. It now listens to `change:resolution` which eliminates many unnecessary calls and it checks if the value in state needs to be updated or not. To test, zoom and pan around the DataPack Library map on `master`, note any lag with zooming and panning. Then checkout this branch `EVK-223-zoom-level-updates` and repeat the zooming/panning. There should be a very noticeable improvement.
*no ui changes*