### PR TITLE
Add headers

### DIFF
--- a/eventkit_cloud/gunicorn.py
+++ b/eventkit_cloud/gunicorn.py
@@ -24,7 +24,6 @@ class Response(wsgi.Response):
         additional_headers = json.loads(os.getenv("HTTP_HEADERS", "{}"))
         for header, value in additional_headers.items():
             headers.append(build_header(header, value.replace('"', "'")))
-        headers.append(build_header("Strict-Transport-Security", "max-age=31536000"))
         return [header for header in headers if not header.startswith("Server:")]
 
 


### PR DESCRIPTION
# Description of Improvement

Allows to optionally set http headers.

## How to test

Add HTTP_HEADERS with a json value to the environment then check any response to ensure that it is set. 

## Quality Assurance

The following items have been updated:

- [x] Linters pass.
- [x] Unittests pass.
- [x] The docs have been updated for any changes to the settings module.
- [x] New tests have been added to reproduce the functionality of the above description.
- [x] Comments have been added to declare intent, or because of some wild comprehension statement.
- [x] UI enhancements have screenshots attached below.
- [x] Screenshots, code, or descriptions don't include proprietary information.

## Screenshots

<!-- If this includes a UI enhancement include a screenshot -->

:smile:
